### PR TITLE
[BotW] DivineLaserBeams: Make transparency and saturation settable + UX improvements

### DIFF
--- a/src/BreathOfTheWild/Mods/DivineLaserBeam/6fa2baef8a4ece42_0000000000000709_ps.txt
+++ b/src/BreathOfTheWild/Mods/DivineLaserBeam/6fa2baef8a4ece42_0000000000000709_ps.txt
@@ -25,9 +25,9 @@
 #define RAINBOW_EFFECT $rainbow // [0 or 1] set it to 1 to enable rainbow beams effect. in that case, HUE_ROTATION is ignored
 #define DISABLE_BEAMS $disableBeams // [0 or 1] set it to 1 to hide the lasers completely
 #define HUE_ROTATION $hue //[0, 360] where 0 and 360 is unchanged Hue and 180 is completely opposite Hue. Check http://i.imgur.com/5UpyIGh.png
-#define SATURATION_FACTOR 1.0 //[0.0, 1.0] 1.0 means unchanged Saturation, 0.0 means completely desaturated. Values above 1.0 are accepted, but they may cause clipping
+#define SATURATION_FACTOR $saturation //[0.0, 1.0] 1.0 means unchanged Saturation, 0.0 means completely desaturated. Values above 1.0 are accepted, but they may cause clipping
 #define VALUE_FACTOR 1.0 //same as above; applies to Value
-#define ALPHA_FACTOR 1.0 //same as above; applies to Transparency
+#define ALPHA_FACTOR $alpha //same as above; applies to Transparency
 
 const float hueRotation = HUE_ROTATION / 360.0;
 

--- a/src/BreathOfTheWild/Mods/DivineLaserBeam/de960d36a997b34d_0000000000000709_ps.txt
+++ b/src/BreathOfTheWild/Mods/DivineLaserBeam/de960d36a997b34d_0000000000000709_ps.txt
@@ -25,9 +25,9 @@
 #define RAINBOW_EFFECT $rainbow // [0 or 1] set it to 1 to enable rainbow beams effect. in that case, HUE_ROTATION is ignored
 #define DISABLE_BEAMS $disableBeams // [0 or 1] set it to 1 to hide the lasers completely
 #define HUE_ROTATION $hue //[0, 360] where 0 and 360 is unchanged Hue and 180 is completely opposite Hue. Check http://i.imgur.com/5UpyIGh.png
-#define SATURATION_FACTOR 1.0 //[0.0, 1.0] 1.0 means unchanged Saturation, 0.0 means completely desaturated. Values above 1.0 are accepted, but they may cause clipping
+#define SATURATION_FACTOR $saturation //[0.0, 1.0] 1.0 means unchanged Saturation, 0.0 means completely desaturated. Values above 1.0 are accepted, but they may cause clipping
 #define VALUE_FACTOR 1.0 //same as above; applies to Value
-#define ALPHA_FACTOR 1.0 //same as above; applies to Transparency
+#define ALPHA_FACTOR $alpha //same as above; applies to Transparency
 
 const float hueRotation = HUE_ROTATION / 360.0;
 #ifdef VULKAN

--- a/src/BreathOfTheWild/Mods/DivineLaserBeam/rules.txt
+++ b/src/BreathOfTheWild/Mods/DivineLaserBeam/rules.txt
@@ -2,60 +2,126 @@
 titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = Divine Laser Beams
 path = "The Legend of Zelda: Breath of the Wild/Mods/Divine Laser Beams"
-description = Allows customization of the color of the Divine Beasts's Laser Beams. They can also be completely hidden.||Made by Kiri.
+description = Customizes the appearance of the Divine Beasts's Laser Beams. They can also be completely hidden.||Made by Kiri.
 version = 6
 
 [Default]
 $hue:int = 0
 $rainbow:int = 0
 $disableBeams:int = 0
+$saturation = 1.0
+$alpha = 1.0
 
 
 [Preset]
-name = Disabled (Default)
-category = Hide Laser
+name = Yes (Default)
+category = Show Laser
 default = 1
 $disableBeams:int = 0
 
 [Preset]
-name = Enabled
-category = Hide Laser
-default = 1
+name = No
+category = Show Laser
 $disableBeams:int = 1
 
 
 [Preset]
 name = Red (Default)
+condition = $disableBeams == 0
 category = Laser Color
 default = 1
 $hue:int = 0
 
 [Preset]
 name = Rainbow
+condition = $disableBeams == 0
 category = Laser Color
 $rainbow:int = 1
 
 [Preset]
 name = Purple
+condition = $disableBeams == 0
 category = Laser Color
 $hue:int = 300
 
 [Preset]
 name = Blue
+condition = $disableBeams == 0
 category = Laser Color
 $hue:int = 225
 
 [Preset]
 name = Cyan
+condition = $disableBeams == 0
 category = Laser Color
 $hue:int = 160
 
 [Preset]
 name = Green
+condition = $disableBeams == 0
 category = Laser Color
 $hue:int = 120
 
 [Preset]
 name = Yellow
+condition = $disableBeams == 0
 category = Laser Color
 $hue:int = 45
+
+
+[Preset]
+name = 100% (Default)
+condition = $disableBeams == 0
+category = Color Saturation
+default = 1
+$saturation = 1.0
+
+[Preset]
+name = 75%
+condition = $disableBeams == 0
+category = Color Saturation
+$saturation = 0.75
+
+[Preset]
+name = 50%
+condition = $disableBeams == 0
+category = Color Saturation
+$saturation = 0.5
+
+[Preset]
+name = 25%
+condition = $disableBeams == 0
+category = Color Saturation
+$saturation = 0.25
+
+
+[Preset]
+name = 100% (Default)
+condition = $disableBeams == 0
+category = Laser Transparency
+default = 1
+$alpha = 1.0
+
+[Preset]
+name = 75%
+condition = $disableBeams == 0
+category = Laser Transparency
+$alpha = 0.75
+
+[Preset]
+name = 50%
+condition = $disableBeams == 0
+category = Laser Transparency
+$alpha = 0.5
+
+[Preset]
+name = 25%
+condition = $disableBeams == 0
+category = Laser Transparency
+$alpha = 0.25
+
+[Preset]
+name = 10%
+condition = $disableBeams == 0
+category = Laser Transparency
+$alpha = 0.1


### PR DESCRIPTION
Let me join the excitement for BotW v6 packs 😛 

Since the first version of the pack made by Kiri, it was possible to change beams saturation and transparency by manually editing the shaders.
When I ported the pack to version 3, it wasn't possible to have preset categories, so I couldn't add a way to change those two options in the UI. But now we can, so I did it! 🎉 
Users can now choose between 100%, 75%, 50% and 25% for color saturation. For transparency is the same, plus a 10% option (for those who prefer barely visible beams).
I've also reworded the enable/disable beams preset to be a little clearer and hidden all color options if beams are disabled.

PS: there is third settable constant in the shaders, which is "value". I didn't make it editable from the UI because it seemed to behave like transparency.