### PR TITLE
[Sonic Boom] Disable Version String patch

### DIFF
--- a/src/SonicBoomRiseOfLyric/Mods/DisableVersionString/patch_DisableVersionString.asm
+++ b/src/SonicBoomRiseOfLyric/Mods/DisableVersionString/patch_DisableVersionString.asm
@@ -1,0 +1,5 @@
+[WiiULauncher16]
+moduleMatches = 0x113CC316
+
+; Overwrite version string with null
+0x102EBF14 = .string ""

--- a/src/SonicBoomRiseOfLyric/Mods/DisableVersionString/rules.txt
+++ b/src/SonicBoomRiseOfLyric/Mods/DisableVersionString/rules.txt
@@ -1,0 +1,6 @@
+[Definition]
+titleIds = 0005000010175B00,0005000010177800,0005000010191F00
+name = Disable Version String
+path = "Sonic Boom: Rise of Lyric/Mods/Disable Version String"
+description = This patches out the version string that lingers around at the top-left of the screen.||Made by HyperBE32.
+version = 6


### PR DESCRIPTION
Hides the version string that lingers around on the menus in the patched version of the game.