### PR TITLE
[Sonic Boom] Disable Intro Logos patch

### DIFF
--- a/src/SonicBoomRiseOfLyric/Mods/DevLevelSelect/rules.txt
+++ b/src/SonicBoomRiseOfLyric/Mods/DevLevelSelect/rules.txt
@@ -2,5 +2,5 @@
 titleIds = 0005000010175B00,0005000010177800,0005000010191F00
 name = Dev Level Select
 path = "Sonic Boom: Rise of Lyric/Mods/Dev Level Select"
-description = This enables the game's Dev Level Select.||Made by M&&M.
+description = This enables the game's Dev Level Select.||Made by M&&M and HyperBE32.
 version = 6

--- a/src/SonicBoomRiseOfLyric/Mods/DisableIntroLogos/patch_DisableIntroLogos.asm
+++ b/src/SonicBoomRiseOfLyric/Mods/DisableIntroLogos/patch_DisableIntroLogos.asm
@@ -1,0 +1,17 @@
+[WiiULauncher0]
+moduleMatches = 0x90DAC5CE
+
+; Jump to title from Japanese video
+0x34BA068 = b 0x34BA2C8
+
+; Jump to title from English video
+0x34BA074 = b 0x34BA2C8
+
+[WiiULauncher16]
+moduleMatches = 0x113CC316
+
+; Jump to title from Japanese video
+0x34BA4B8 = b 0x34BA760
+
+; Jump to title from English video
+0x34BA4C4 = b 0x34BA760

--- a/src/SonicBoomRiseOfLyric/Mods/DisableIntroLogos/rules.txt
+++ b/src/SonicBoomRiseOfLyric/Mods/DisableIntroLogos/rules.txt
@@ -1,0 +1,6 @@
+[Definition]
+titleIds = 0005000010175B00,0005000010177800,0005000010191F00
+name = Disable Intro Logos
+path = "Sonic Boom: Rise of Lyric/Mods/Disable Intro Logos"
+description = This patches out the intro logos at the beginning of the game.||Made by HyperBE32.
+version = 6


### PR DESCRIPTION
Disables the unskippable logos that appear at the start of the game that take a horrifically long time to pass.