### PR TITLE
[Sonic Boom] Fix Pause State Reset

### DIFF
--- a/src/SonicBoomRiseOfLyric/Mods/FixPauseStateReset/patch_FixPauseStateReset.asm
+++ b/src/SonicBoomRiseOfLyric/Mods/FixPauseStateReset/patch_FixPauseStateReset.asm
@@ -1,0 +1,23 @@
+[WiiULauncher0US]
+moduleMatches = 0x90DAC5CE
+
+; Skip CBrbAICompanion::ForceIdle subroutine
+0x306EBA0 = nop
+
+[WiiULauncher0EU]
+moduleMatches = 0x8F7D2702
+
+; Skip CBrbAICompanion::ForceIdle subroutine
+0x306EB80 = nop
+
+[WiiULauncher0JP]
+moduleMatches = 0x0D395735
+
+; Skip CBrbAICompanion::ForceIdle subroutine
+0x306EA30 = nop
+
+[WiiULauncher16]
+moduleMatches = 0x113CC316
+
+; Skip CBrbAICompanion::ForceIdle subroutine
+0x306EDBC = nop

--- a/src/SonicBoomRiseOfLyric/Mods/FixPauseStateReset/rules.txt
+++ b/src/SonicBoomRiseOfLyric/Mods/FixPauseStateReset/rules.txt
@@ -1,0 +1,6 @@
+[Definition]
+titleIds = 0005000010175B00,0005000010177800,0005000010191F00
+name = Fix Pause State Reset
+path = "Sonic Boom: Rise of Lyric/Mods/Fix Pause State Reset"
+description = This patches out an issue where all players' states reset to idle after unpausing the game.||Made by HyperBE32.
+version = 6


### PR DESCRIPTION
Fixes a silly bug where all players reset their states to idle after unpausing the game.