### PR TITLE
[Sonic Boom] Unlock All Money Bags

### DIFF
--- a/src/SonicBoomRiseOfLyric/Cheats/UnlockAllMoneyBags/patch_UnlockAllMoneyBags.asm
+++ b/src/SonicBoomRiseOfLyric/Cheats/UnlockAllMoneyBags/patch_UnlockAllMoneyBags.asm
@@ -1,0 +1,59 @@
+[WiiULauncher0US]
+moduleMatches = 0x90DAC5CE
+
+; Jump to success condition
+0x34BD3E4 = b 0x34BD524
+
+; Force loop to iterate four times to unlock all bonuses
+0x34BD544 = li r27, 4
+
+; Branch back to first condition to unlock the UI
+0x34BD5AC = b 0x34BD4FC
+
+; Skip saving callback in 3DS response payload
+0x34BFCB8 = nop
+
+[WiiULauncher0EU]
+moduleMatches = 0x8F7D2702
+
+; Jump to success condition
+0x34BD480 = b 0x34BD5CC
+
+; Force loop to iterate four times to unlock all bonuses
+0x34BD5EC = li r27, 4
+
+; Branch back to first condition to unlock the UI
+0x34BD654 = b 0x34BD5A4
+
+; Skip saving callback in 3DS response payload
+0x34BFD6C = nop
+
+[WiiULauncher0JP]
+moduleMatches = 0x0D395735
+
+; Jump to success condition
+0x34BD7DC = b 0x34BD928
+
+; Force loop to iterate four times to unlock all bonuses
+0x34BD948 = li r27, 4
+
+; Branch back to first condition to unlock the UI
+0x34BD9B0 = b 0x34BD900
+
+; Skip saving callback in 3DS response payload
+0x34C0128 = nop
+
+[WiiULauncher16]
+moduleMatches = 0x113CC316
+
+; Jump to success condition
+0x34BD898 = b 0x34BD9E4
+
+; Force loop to iterate four times to unlock all bonuses
+0x34BDA04 = li r27, 4
+
+; Branch back to first condition to unlock the UI
+0x34BDA6C = b 0x34BD9BC
+
+; Skip saving callback in 3DS response payload
+0x34C0184 = nop

--- a/src/SonicBoomRiseOfLyric/Cheats/UnlockAllMoneyBags/rules.txt
+++ b/src/SonicBoomRiseOfLyric/Cheats/UnlockAllMoneyBags/rules.txt
@@ -1,0 +1,6 @@
+[Definition]
+titleIds = 0005000010175B00,0005000010177800,0005000010191F00
+name = Unlock All Money Bags
+path = "Sonic Boom: Rise of Lyric/Cheats/Unlock All Money Bags"
+description = This patch unlocks all Money Bags that are locked behind 3DS integration and having completed Sonic Boom: Shattered Crystal for Nintendo 3DS.||Made by HyperBE32.
+version = 6

--- a/src/SonicBoomRiseOfLyric/Cheats/UnlockAllMoneyBags/rules.txt
+++ b/src/SonicBoomRiseOfLyric/Cheats/UnlockAllMoneyBags/rules.txt
@@ -2,5 +2,5 @@
 titleIds = 0005000010175B00,0005000010177800,0005000010191F00
 name = Unlock All Money Bags
 path = "Sonic Boom: Rise of Lyric/Cheats/Unlock All Money Bags"
-description = This patch unlocks all Money Bags that are locked behind 3DS integration and having completed Sonic Boom: Shattered Crystal for Nintendo 3DS.||Made by HyperBE32.
+description = This patch unlocks all Money Bags that are locked behind Nintendo 3DS integration and having completed Sonic Boom: Shattered Crystal.||Made by HyperBE32.
 version = 6


### PR DESCRIPTION
Bypasses that dumb 3DS requirement for some extra rings.