### PR TITLE
[Sonic Boom] Disable Camera Shake

### DIFF
--- a/src/SonicBoomRiseOfLyric/Enhancements/DisableEventCameraShake/patch_DisableEventCameraShake.asm
+++ b/src/SonicBoomRiseOfLyric/Enhancements/DisableEventCameraShake/patch_DisableEventCameraShake.asm
@@ -1,0 +1,23 @@
+[WiiULauncher0US]
+moduleMatches = 0x90DAC5CE
+
+; Skip shake initialisation in CView::ProcessShakeNormal
+0x2AEA96C = b 0x2AEAA0C
+
+[WiiULauncher0EU]
+moduleMatches = 0x8F7D2702
+
+; Skip shake initialisation in CView::ProcessShakeNormal
+0x2AEA94C = b 0x2AEA9EC
+
+[WiiULauncher0JP]
+moduleMatches = 0x0D395735
+
+; Skip shake initialisation in CView::ProcessShakeNormal
+0x2AEA988 = b 0x2AEAA28
+
+[WiiULauncher16]
+moduleMatches = 0x113CC316
+
+; Skip shake initialisation in CView::ProcessShakeNormal
+0x2AEA9A8 = b 0x2AEAA48

--- a/src/SonicBoomRiseOfLyric/Enhancements/DisableEventCameraShake/rules.txt
+++ b/src/SonicBoomRiseOfLyric/Enhancements/DisableEventCameraShake/rules.txt
@@ -1,0 +1,6 @@
+[Definition]
+titleIds = 0005000010175B00,0005000010177800,0005000010191F00
+name = Disable Event Camera Shake
+path = "Sonic Boom: Rise of Lyric/Enhancements/Disable Event Camera Shake"
+description = This patches out camera shake tied to events.||Made by HyperBE32.
+version = 6

--- a/src/SonicBoomRiseOfLyric/Enhancements/DisablePlayerCameraShake/patch_DisablePlayerCameraShake.asm
+++ b/src/SonicBoomRiseOfLyric/Enhancements/DisablePlayerCameraShake/patch_DisablePlayerCameraShake.asm
@@ -1,0 +1,23 @@
+[WiiULauncher0US]
+moduleMatches = 0x90DAC5CE
+
+; Skip shake initialisation in CBrbGameCamera::InitializeCameraShakes
+0x309CA08 = b 0x309CBE8
+
+[WiiULauncher0EU]
+moduleMatches = 0x8F7D2702
+
+; Skip shake initialisation in CBrbGameCamera::InitializeCameraShakes
+0x309CA70 = b 0x309CC50
+
+[WiiULauncher0JP]
+moduleMatches = 0x0D395735
+
+; Skip shake initialisation in CBrbGameCamera::InitializeCameraShakes
+0x309CA28 = b 0x309CC08
+
+[WiiULauncher16]
+moduleMatches = 0x113CC316
+
+; Skip shake initialisation in CBrbGameCamera::InitializeCameraShakes
+0x309CC28 = b 0x309CE08

--- a/src/SonicBoomRiseOfLyric/Enhancements/DisablePlayerCameraShake/rules.txt
+++ b/src/SonicBoomRiseOfLyric/Enhancements/DisablePlayerCameraShake/rules.txt
@@ -1,0 +1,6 @@
+[Definition]
+titleIds = 0005000010175B00,0005000010177800,0005000010191F00
+name = Disable Player Camera Shake
+path = "Sonic Boom: Rise of Lyric/Enhancements/Disable Player Camera Shake"
+description = This patches out camera shake tied to player movement.||Made by HyperBE32.
+version = 6


### PR DESCRIPTION
Two separate patches that disable either player-related camera shake or event-related camera shake.

If patch conditions are introduced to Cemu in the future, these may be combined into a single graphic pack - for the sake of everyone's sanity, they are separate for now.