### PR TITLE
[Sonic Boom] Infinite Currency

### DIFF
--- a/src/SonicBoomRiseOfLyric/Cheats/InfiniteRobotScrap/patch_InfiniteRobotScrap.asm
+++ b/src/SonicBoomRiseOfLyric/Cheats/InfiniteRobotScrap/patch_InfiniteRobotScrap.asm
@@ -1,0 +1,79 @@
+[WiiULauncher0US]
+moduleMatches = 0x90DAC5CE
+
+; Skip verification checks for robot scrap in BRBUIVars::verify_preorders
+0x329DB7C = nop
+0x329DB88 = nop
+0x329DBB8 = nop
+0x329DBC4 = nop
+
+; Skip argument check before executing BRBRingBank::Set_RobotParts in the upgrade manager
+0x308285C = nop
+
+; Load 999999 into register 5 for all BRBRingBank::Set_RobotParts and BRBRingBank::Add_RobotParts instances
+0x30825D0 = stw r5, 0x10(r31)
+0x3285C5C = stw r5, 0x10(r31)
+0x329AA6C = stw r5, 0x10(r31)
+0x3466C3C = stw r5, 0x10(r31)
+0x34B451C = stw r5, 0x10(r31)
+0x34B76FC = stw r5, 0x10(r31)
+
+[WiiULauncher0EU]
+moduleMatches = 0x8F7D2702
+
+; Skip verification checks for robot scrap in BRBUIVars::verify_preorders
+0x329DC14 = nop
+0x329DC20 = nop
+0x329DC50 = nop
+0x329DC5C = nop
+
+; Skip argument check before executing BRBRingBank::Set_RobotParts in the upgrade manager
+0x30828B4 = nop
+
+; Load 999999 into register 5 for all BRBRingBank::Set_RobotParts and BRBRingBank::Add_RobotParts instances
+0x3082628 = stw r5, 0x10(r31)
+0x3285CF4 = stw r5, 0x10(r31)
+0x329AB04 = stw r5, 0x10(r31)
+0x3466CD4 = stw r5, 0x10(r31)
+0x34B45B4 = stw r5, 0x10(r31)
+0x34B7794 = stw r5, 0x10(r31)
+
+[WiiULauncher0JP]
+moduleMatches = 0x0D395735
+
+; Skip verification checks for robot scrap in BRBUIVars::verify_preorders
+0x329DF04 = nop
+0x329DF10 = nop
+0x329DF40 = nop
+0x329DF4C = nop
+
+; Skip argument check before executing BRBRingBank::Set_RobotParts in the upgrade manager
+0x3082858 = nop
+
+; Load 999999 into register 5 for all BRBRingBank::Set_RobotParts and BRBRingBank::Add_RobotParts instances
+0x30825CC = stw r5, 0x10(r31)
+0x3285F98 = stw r5, 0x10(r31)
+0x329ADC8 = stw r5, 0x10(r31)
+0x3467010 = stw r5, 0x10(r31)
+0x34B48F4 = stw r5, 0x10(r31)
+0x34B7AD4 = stw r5, 0x10(r31)
+
+[WiiULauncher16]
+moduleMatches = 0x113CC316
+
+; Skip verification checks for robot scrap in BRBUIVars::verify_preorders
+0x329DFCC = nop
+0x329DFD8 = nop
+0x329E008 = nop
+0x329E014 = nop
+
+; Skip argument check before executing BRBRingBank::Set_RobotParts in the upgrade manager
+0x3082A7C = nop
+
+; Load 999999 into register 5 for all BRBRingBank::Set_RobotParts instances
+0x30827F0 = stw r5, 0x10(r31)
+0x328608C = stw r5, 0x10(r31)
+0x329AEBC = stw r5, 0x10(r31)
+0x34670A0 = stw r5, 0x10(r31)
+0x34B496C = stw r5, 0x10(r31)
+0x34B7B4C = stw r5, 0x10(r31)

--- a/src/SonicBoomRiseOfLyric/Cheats/InfiniteRobotScrap/rules.txt
+++ b/src/SonicBoomRiseOfLyric/Cheats/InfiniteRobotScrap/rules.txt
@@ -1,0 +1,6 @@
+[Definition]
+titleIds = 0005000010175B00,0005000010177800,0005000010191F00
+name = Infinite Robot Scrap
+path = "Sonic Boom: Rise of Lyric/Cheats/Infinite Robot Scrap"
+description = This patch constantly awards the player with the maximum amount of robot scrap. These can be spent on upgrades or improving hub areas.||Made by HyperBE32.
+version = 6

--- a/src/SonicBoomRiseOfLyric/Cheats/InfiniteTotalRings/patch_InfiniteTotalRings.asm
+++ b/src/SonicBoomRiseOfLyric/Cheats/InfiniteTotalRings/patch_InfiniteTotalRings.asm
@@ -1,0 +1,71 @@
+[WiiULauncher0US]
+moduleMatches = 0x90DAC5CE
+
+; Skip verification checks for total rings in BRBUIVars::verify_preorders
+0x329DAE8 = nop
+0x329DAF4 = nop
+0x329DB24 = nop
+0x329DB30 = nop
+
+; Load 999999 into register 5 for all BRBRingBank::Set_GlobalRings and BRBRingBank::Add_GlobalRings instances
+0x32863E8 = stw r5, 0xC(r31)
+0x329A9F0 = stw r5, 0xC(r31)
+0x334654C = stw r5, 0xC(r31)
+0x334C638 = stw r5, 0xC(r31)
+0x3466BB4 = stw r5, 0xC(r31)
+0x3475FA0 = stw r5, 0xC(r31)
+0x347DE04 = stw r5, 0xC(r31)
+
+[WiiULauncher0EU]
+moduleMatches = 0x8F7D2702
+
+; Skip verification checks for total rings in BRBUIVars::verify_preorders
+0x329DB80 = nop
+0x329DB8C = nop
+0x329DBBC = nop
+0x329DBC8 = nop
+
+; Load 999999 into register 5 for all BRBRingBank::Set_GlobalRings and BRBRingBank::Add_GlobalRings instances
+0x3286480 = stw r5, 0xC(r31)
+0x329AA88 = stw r5, 0xC(r31)
+0x33465E4 = stw r5, 0xC(r31)
+0x334C6D0 = stw r5, 0xC(r31)
+0x3466C4C = stw r5, 0xC(r31)
+0x3476038 = stw r5, 0xC(r31)
+0x347DE9C = stw r5, 0xC(r31)
+
+[WiiULauncher0JP]
+moduleMatches = 0x0D395735
+
+; Skip verification checks for total rings in BRBUIVars::verify_preorders
+0x329DE70 = nop
+0x329DE7C = nop
+0x329DEAC = nop
+0x329DEB8 = nop
+
+; Load 999999 into register 5 for all BRBRingBank::Set_GlobalRings and BRBRingBank::Add_GlobalRings instances
+0x3286724 = stw r5, 0xC(r31)
+0x329AD4C = stw r5, 0xC(r31)
+0x33468E4 = stw r5, 0xC(r31)
+0x334C9D0 = stw r5, 0xC(r31)
+0x3466F88 = stw r5, 0xC(r31)
+0x34763B0 = stw r5, 0xC(r31)
+0x347E214 = stw r5, 0xC(r31)
+
+[WiiULauncher16]
+moduleMatches = 0x113CC316
+
+; Skip verification checks for total rings in BRBUIVars::verify_preorders
+0x329DF38 = nop
+0x329DF44 = nop
+0x329DF74 = nop
+0x329DF80 = nop
+
+; Load 999999 into register 5 for all BRBRingBank::Set_GlobalRings and BRBRingBank::Add_GlobalRings instances
+0x3286818 = stw r5, 0xC(r31)
+0x329AE40 = stw r5, 0xC(r31)
+0x33469B0 = stw r5, 0xC(r31)
+0x334CA9C = stw r5, 0xC(r31)
+0x3467018 = stw r5, 0xC(r31)
+0x3476404 = stw r5, 0xC(r31)
+0x347E268 = stw r5, 0xC(r31)

--- a/src/SonicBoomRiseOfLyric/Cheats/InfiniteTotalRings/rules.txt
+++ b/src/SonicBoomRiseOfLyric/Cheats/InfiniteTotalRings/rules.txt
@@ -1,0 +1,6 @@
+[Definition]
+titleIds = 0005000010175B00,0005000010177800,0005000010191F00
+name = Infinite Total Rings
+path = "Sonic Boom: Rise of Lyric/Cheats/Infinite Total Rings"
+description = This patch constantly awards the player with the maximum amount of total rings. These can be used to access unlockables from Q-N-C's Database.||Made by HyperBE32.
+version = 6


### PR DESCRIPTION
Two separate patches that award the player with 999,999 robot scrap and 999,999 total rings.

The former is kinda useless for upgrades right now, as infinite crowns are yet to be figured out.

Soon™