### PR TITLE
[Sonic Boom] Disable Combo Reset

### DIFF
--- a/src/SonicBoomRiseOfLyric/Cheats/DisableComboReset/patch_DisableComboReset.asm
+++ b/src/SonicBoomRiseOfLyric/Cheats/DisableComboReset/patch_DisableComboReset.asm
@@ -1,0 +1,23 @@
+[WiiULauncher0US]
+moduleMatches = 0x90DAC5CE
+
+; Skip BRBCharacter::ResetCombo
+0x323C888 = blr
+
+[WiiULauncher0EU]
+moduleMatches = 0x8F7D2702
+
+; Skip BRBCharacter::ResetCombo
+0x323C920 = blr
+
+[WiiULauncher0JP]
+moduleMatches = 0x0D395735
+
+; Skip BRBCharacter::ResetCombo
+0x323CBB0 = blr
+
+[WiiULauncher16]
+moduleMatches = 0x113CC316
+
+; Skip BRBCharacter::ResetCombo
+0x323CCA0 = blr

--- a/src/SonicBoomRiseOfLyric/Cheats/DisableComboReset/rules.txt
+++ b/src/SonicBoomRiseOfLyric/Cheats/DisableComboReset/rules.txt
@@ -1,0 +1,6 @@
+[Definition]
+titleIds = 0005000010175B00,0005000010177800,0005000010191F00
+name = Disable Combo Reset
+path = "Sonic Boom: Rise of Lyric/Cheats/Disable Combo Reset"
+description = This prevents your combos from expiring after a set amount of time or after taking damage.||Made by HyperBE32.
+version = 6


### PR DESCRIPTION
Prevents your combos from expiring regardless, because why not.