### PR TITLE
Laser Transparency -> Laser Opacity

### DIFF
--- a/src/BreathOfTheWild/Mods/DivineLaserBeam/rules.txt
+++ b/src/BreathOfTheWild/Mods/DivineLaserBeam/rules.txt
@@ -98,30 +98,30 @@ $saturation = 0.25
 [Preset]
 name = 100% (Default)
 condition = $disableBeams == 0
-category = Laser Transparency
+category = Laser Opacity
 default = 1
 $alpha = 1.0
 
 [Preset]
 name = 75%
 condition = $disableBeams == 0
-category = Laser Transparency
+category = Laser Opacity
 $alpha = 0.75
 
 [Preset]
 name = 50%
 condition = $disableBeams == 0
-category = Laser Transparency
+category = Laser Opacity
 $alpha = 0.5
 
 [Preset]
 name = 25%
 condition = $disableBeams == 0
-category = Laser Transparency
+category = Laser Opacity
 $alpha = 0.25
 
 [Preset]
 name = 10%
 condition = $disableBeams == 0
-category = Laser Transparency
+category = Laser Opacity
 $alpha = 0.1


### PR DESCRIPTION
"Opacity" is more correct than "transparency" here, as 100% makes the beam fully opaque and 10% makes it almost completely transparent.