### PR TITLE
[Xenoblade X] Adds support for unused weather conditions | Also fixes a mod that could be used for online griefing

### DIFF
--- a/src/XenobladeChroniclesX/Mods/BattleEscapeDistance/rules.txt
+++ b/src/XenobladeChroniclesX/Mods/BattleEscapeDistance/rules.txt
@@ -30,4 +30,4 @@ $mod = 4.0
 
 [Preset]
 name = "Enemies will not fight at all (game breaking)"
-$mod = 500.0
+$mod = 1000.0

--- a/src/XenobladeChroniclesX/Mods/BattleEscapeDistance/rules.txt
+++ b/src/XenobladeChroniclesX/Mods/BattleEscapeDistance/rules.txt
@@ -9,8 +9,8 @@ version = 6
 $mod = 1.0
 
 [Preset]
-name = "Hell: Enemies will never de-aggro"
-$mod = 0.0001
+name = "Enemies will never de-aggro"
+$mod = 0.00001
 
 [Preset]
 name = "Increase Range x2"

--- a/src/XenobladeChroniclesX/Mods/BladeGainTicketsFromMissions/rules.txt
+++ b/src/XenobladeChroniclesX/Mods/BladeGainTicketsFromMissions/rules.txt
@@ -1,7 +1,7 @@
 [Definition]
 titleIds = 0005000010116100,00050000101C4C00,00050000101C4D00
-name = "Gain Reward Tickets from DLC or Time Attack missions"
-path = "Xenoblade Chronicles X/Mods/BLADE/Gain Reward Tickets from DLC or Time Attack missions"
+name = "Gain Reward Tickets from Time Attack missions or DLC"
+path = "Xenoblade Chronicles X/Mods/BLADE/Gain Reward Tickets from Time Attack missions or DLC"
 description = Adds Exchange Tickets in reward of completing Blade missions.|This mod will not work if More Reward Tickets is enabled.
 version = 6
 

--- a/src/XenobladeChroniclesX/Mods/BladeGainTicketsFromMissions/rules.txt
+++ b/src/XenobladeChroniclesX/Mods/BladeGainTicketsFromMissions/rules.txt
@@ -1,7 +1,7 @@
 [Definition]
 titleIds = 0005000010116100,00050000101C4C00,00050000101C4D00
-name = "Gain Reward Tickets from Time Attack missions or DLC"
-path = "Xenoblade Chronicles X/Mods/BLADE/Gain Reward Tickets from Time Attack missions or DLC"
+name = "Gain Reward Tickets from Time Attack or DLC missions"
+path = "Xenoblade Chronicles X/Mods/BLADE/Gain Reward Tickets from Time Attack or DLC missions"
 description = Adds Exchange Tickets in reward of completing Blade missions.|This mod will not work if More Reward Tickets is enabled.
 version = 6
 

--- a/src/XenobladeChroniclesX/Mods/BladeGlobalNemesisMissionsOffline/patch_offline_nemesis.asm
+++ b/src/XenobladeChroniclesX/Mods/BladeGlobalNemesisMissionsOffline/patch_offline_nemesis.asm
@@ -1,6 +1,8 @@
 [XCX_OFFLINEWE]
 moduleMatches = 0xF882D5CF, 0x30B6E091, 0x7672271D, 0x218F6E07, 0xAB97DE6B, 0x676EB33E, 0x785CA8A9 ; 1.0.1E, 1.0.2U, 1.0.2J, 1.0.0E, 1.0.1U, 1.0.0U, 1.0.0J
 .origin = codecave
+.int $ygg
+.int $teli
 
 ; Manage RPs & Appraisal
 VarShareRP:
@@ -31,12 +33,12 @@ moduleMatches = 0xF882D5CF, 0x30B6E091, 0x218F6E07 ; 1.0.1E, 1.0.2U, 1.0.0E
 
 ; collectQuestInfoWE__Q2_3cfs15CfSocialManagerFRQ2_2ml45resvector__tm__28_PQ2_3cfs17CfSocialQuestInfo
 0x022C6254 = li r3, 1 ; fw::SocialDataStore::getWorldEnemyCount(const(void))
-0x022C6280 = li r3, 0x4EE9 ; Quest ID for WE - fw::SocialDataStore::getWorldEnemyQuest(const(unsigned int))
+0x022C6280 = li r3, $teli ; Quest ID for WE - fw::SocialDataStore::getWorldEnemyQuest(const(unsigned int))
 0x022C65A8 = li r3, 1 ; fw::SocialDataStore::getWorldEnemyCount(const(void))
 
 ; collectQuestInfoFR__Q2_3cfs15CfSocialManagerFRQ2_2ml45resvector__tm__28_PQ2_3cfs17CfSocialQuestInfo
 0x022C66CC = li r3, 1 ; fw::SocialDataStore::getWorldEnemyCount(const(void))
-0x022C66FC = li r3, 0x4EED
+0x022C66FC = li r3, $ygg
 0x022C6738 = nop ; network test?
 0x022C6A5C = li r3, 1 ; fw::SocialDataStore::getWorldEnemyCount(const(void))
 
@@ -87,11 +89,11 @@ moduleMatches = 0x7672271D ; 1.0.2J
 0x022C7A70 = nop ; network test
 
 0x022C5C64 = li r3, 1 ; fw::SocialDataStore::getWorldEnemyCount(const(void))
-0x022C5C90 = li r3, 0x4EE9 ; Quest ID for WE - fw::SocialDataStore::getWorldEnemyQuest(const(unsigned int))
+0x022C5C90 = li r3, $teli ; Quest ID for WE - fw::SocialDataStore::getWorldEnemyQuest(const(unsigned int))
 0x022C5FB8 = li r3, 1 ; fw::SocialDataStore::getWorldEnemyCount(const(void))
 
 0x022C60DC = li r3, 1 ; fw::SocialDataStore::getWorldEnemyCount(const(void))
-0x022C610C = li r3, 0x4EED
+0x022C610C = li r3, $ygg
 0x022C6148 = nop ; network test?
 0x022C646C = li r3, 1 ; fw::SocialDataStore::getWorldEnemyCount(const(void))
 
@@ -120,12 +122,13 @@ moduleMatches = 0xAB97DE6B, 0x676EB33E ; 1.0.1U, 1.0.0U
 0x02287960 = nop ; (network test?) allow call to cfs::CfSocialQuestManager::update((void))
 0x022C7FEC = nop ; network test : lwz       r10, 0x1B0(r30) --> rlwinm.   r9, r10, 0,30,30
 0x022C7FF0 = nop ; network test
+
 0x022C61E4 = li r3, 1 ; fw::SocialDataStore::getWorldEnemyCount(const(void))
-0x022C6210 = li r3, 0x4EE9 ; Quest ID for WE - fw::SocialDataStore::getWorldEnemyQuest(const(unsigned int))
+0x022C6210 = li r3, $teli ; Quest ID for WE - fw::SocialDataStore::getWorldEnemyQuest(const(unsigned int))
 0x022C6538 = li r3, 1 ; fw::SocialDataStore::getWorldEnemyCount(const(void))
 
 0x022C665C = li r3, 1 ; fw::SocialDataStore::getWorldEnemyCount(const(void))
-0x022C668C = li r3, 0x4EED
+0x022C668C = li r3, $ygg
 0x022C66C8 = nop ; network test?
 0x022C69EC = li r3, 1 ; fw::SocialDataStore::getWorldEnemyCount(const(void))
 
@@ -156,11 +159,11 @@ moduleMatches = 0x785CA8A9 ; 1.0.0J
 0x022C78FC = nop ; network test
 
 0x022C5AF0 = li r3, 1 ; fw::SocialDataStore::getWorldEnemyCount(const(void))
-0x022C5B1C = li r3, 0x4EE9 ; Quest ID for WE - fw::SocialDataStore::getWorldEnemyQuest(const(unsigned int))
+0x022C5B1C = li r3, $teli ; Quest ID for WE - fw::SocialDataStore::getWorldEnemyQuest(const(unsigned int))
 0x022C5E44 = li r3, 1 ; fw::SocialDataStore::getWorldEnemyCount(const(void))
 
 0x022C5F68 = li r3, 1 ; fw::SocialDataStore::getWorldEnemyCount(const(void))
-0x022C5F98 = li r3, 0x4EED
+0x022C5F98 = li r3, $ygg
 0x022C5FD4 = nop ; network test?
 0x022C62F8 = li r3, 1 ; fw::SocialDataStore::getWorldEnemyCount(const(void))
 

--- a/src/XenobladeChroniclesX/Mods/BladeGlobalNemesisMissionsOffline/rules.txt
+++ b/src/XenobladeChroniclesX/Mods/BladeGlobalNemesisMissionsOffline/rules.txt
@@ -4,3 +4,16 @@ name = "Offline Global Nemesis missions"
 path = "Xenoblade Chronicles X/Mods/BLADE/Offline Global Nemesis missions"
 description = Global Nemesis (both Telethia Plume and Yggralith Zero) are available in the BLADE console.|You still need medals to start the battle.
 version = 6
+
+[Default]
+$ygg = 0x4EED
+$teli = 0x4EE9
+
+[Preset]
+category = "Telethia Bossfight Version"
+name = "Monday Telethia (rising energy mist - time: 0:00)"
+
+[Preset]
+category = "Telethia Bossfight Version"
+name = "Friday Telethia (thunderstorms - time: 15:00)"
+$teli = 0x4EE8

--- a/src/XenobladeChroniclesX/Mods/BladeTasksAndMissionsOffline/patch_offline_squad.asm
+++ b/src/XenobladeChroniclesX/Mods/BladeTasksAndMissionsOffline/patch_offline_squad.asm
@@ -91,6 +91,7 @@ moduleMatches = 0xF882D5CF, 0x218F6E07 ; 1.0.1E, 1.0.0E
 
 ;################## BLADE Home Terminal (for Squad Quest Selection)
 0x02AC5C10 = li r3, 0 ; menu::CTerminalMenu_SquadQuest::offline
+0x02E0C5B0 = li r3, -1
 
 ;################## Change Squad Mission using main menu
 0x02B85134 = bla _savePtr
@@ -112,6 +113,7 @@ moduleMatches = 0x30B6E091 ; 1.0.2U
 
 ;################## BLADE Home Terminal (for Squad Quest Selection)
 0x02AC5C00 = li r3, 0 ; menu::CTerminalMenu_SquadQuest::offline
+0x02E0C550 = li r3, -1
 
 ;################## Change Squad Mission using main menu
 0x02B85124 = bla _savePtr
@@ -152,6 +154,7 @@ moduleMatches = 0x7672271D ; 1.0.2J
 0x0295B7F0 = li r0, 42
 0x02BF81D0 = li r11, 1 ; garder affichée la liste des tasks en bas à droite ; keep displayed the list of tasks at the bottom right
 0x02AC22D0 = li r3, 0 ; menu::CTerminalMenu_SquadQuest::offline
+0x02E07A78 = li r3, -1
 0x02B81070 = bla _savePtr
 0x02B81088 = bla _savePtr
 0x02B80FC0 = li r11, 1
@@ -189,6 +192,7 @@ moduleMatches = 0xAB97DE6B, 0x676EB33E ; 1.0.1U, 1.0.0U
 0x0295E988 = li r0, 42
 0x02BFC6C0 = li r11, 1 ; garder affichée la liste des tasks en bas à droite ; keep displayed the list of tasks at the bottom right
 0x02AC5B84 = li r3, 0 ; menu::CTerminalMenu_SquadQuest::offline
+0x02E0C3D8 = li r3, -1
 0x02B850A8 = bla _savePtr
 0x02B850C0 = bla _savePtr
 0x02B84FF8 = li r11, 1
@@ -226,6 +230,7 @@ moduleMatches = 0xAB97DE6B, 0x676EB33E ; 1.0.1U, 1.0.0U
 ;0x0295A060 = li r0, 42
 ;0x02BF5364 = li r11, 1 ; garder affichée la liste des tasks en bas à droite ; keep displayed the list of tasks at the bottom right
 ;0x02AC04E8 = li r3, 0 ; menu::CTerminalMenu_SquadQuest::offline
+;0x02E03228 = li r3, -1
 ;0x02B7EAC0 = bla _savePtr
 ;0x02B7EAD8 = bla _savePtr
 ;0x02B7EA10 = li r11, 1

--- a/src/XenobladeChroniclesX/Mods/BladeTasksAndMissionsOffline/rules.txt
+++ b/src/XenobladeChroniclesX/Mods/BladeTasksAndMissionsOffline/rules.txt
@@ -2,7 +2,7 @@
 titleIds = 0005000010116100,00050000101C4C00,00050000101C4D00
 name = "Squad tasks and missions are available offline"
 path = "Xenoblade Chronicles X/Mods/BLADE/Offline Squad tasks and missions"
-description = Squad tasks and missions are available offline. Presets allow to select a Squad Mission, or you can use [Social > Squad Select] menu for random selection.||Recommended to be combined with More Reward Tickets (x5).||Mod will not work "Enable Online Mode" is on!!
+description = Squad tasks and missions are available offline. Presets allow to select a Squad Mission, or you can use [Social > Squad Select] menu for random selection.||Recommended to be combined with More Reward Tickets (x5).||"Enable Online Mode" setting must be OFF for the mod to work!!
 version = 6
 
 [Default]

--- a/src/XenobladeChroniclesX/Mods/BladeTasksAndMissionsOffline/rules.txt
+++ b/src/XenobladeChroniclesX/Mods/BladeTasksAndMissionsOffline/rules.txt
@@ -2,7 +2,7 @@
 titleIds = 0005000010116100,00050000101C4C00,00050000101C4D00
 name = "Squad tasks and missions are available offline"
 path = "Xenoblade Chronicles X/Mods/BLADE/Offline Squad tasks and missions"
-description = Squad tasks and missions are available offline. Presets allow to select a Squad Mission, or you can use [Social > Squad Select] menu for random selection.||Recommended to be combined with More Reward Tickets (x5).
+description = Squad tasks and missions are available offline. Presets allow to select a Squad Mission, or you can use [Social > Squad Select] menu for random selection.||Recommended to be combined with More Reward Tickets (x5).||Mod will not work "Enable Online Mode" is on!!
 version = 6
 
 [Default]
@@ -110,3 +110,7 @@ $missionId = 24
 [Preset]
 name = "N25: Unused squad mission"
 $missionId = 25
+
+[Preset]
+name = "N00: Broken squad mission"
+$missionId = 26

--- a/src/XenobladeChroniclesX/Mods/ExpBladePointsX/patch_exp_blade.asm
+++ b/src/XenobladeChroniclesX/Mods/ExpBladePointsX/patch_exp_blade.asm
@@ -18,11 +18,11 @@ moduleMatches = 0x30B6E091 ; 1.0.2U
 0x02E0C550 = li r3, -1
 0x0288E614 = li r3, $mod
 
-;[XCX_BLADEX_V102J]
-;moduleMatches = 0x7672271D ; 1.0.2J
-;0x = nop ; broken
-;0x = li r3, -1 ; broken
-;0x = li r3, $mod ; broken
+[XCX_BLADEX_V102J]
+moduleMatches = 0x7672271D ; 1.0.2J
+0x0288B470 = nop
+0x02E07A78 = li r3, -1
+0x0288B474 = li r3, $mod
 
 [XCX_BLADEX_V100U]
 moduleMatches = 0xAB97DE6B, 0x676EB33E ; 1.0.1U, 1.0.0U

--- a/src/XenobladeChroniclesX/Mods/HUDFreecam/rules.txt
+++ b/src/XenobladeChroniclesX/Mods/HUDFreecam/rules.txt
@@ -2,5 +2,5 @@
 titleIds = 0005000010116100,00050000101C4C00,00050000101C4D00
 name = "Freecam"
 path = "Xenoblade Chronicles X/Mods/HUD/Freecam"
-description = Look around the world with the developer freecam.|The game functions like normal when you're in this mode. Area renders around camera, so going too far will make your character have no ground and die.||Made by blingbloing, modified by intra.|||Hold 'R' button to move camera up|Hold 'L' button to move camera down|Hold 'X' button to keep camera in place|Hold 'Y' button to speed up camera|Tip: Press and hold the R stick button to speed up even more
+description = Look around the world with the developer freecam.|The game functions like normal when you're in this mode. Area renders around camera, so going too far will make your character have no ground and die.||Mod made by blingbloing.|||Hold 'R' button to move camera up|Hold 'L' button to move camera down|Hold 'X' button to keep camera in place|Hold 'Y' button to speed up camera|Tip: Press and hold the R stick button to speed up even more
 version = 6

--- a/src/XenobladeChroniclesX/Mods/WeatherForceWeather/rules.txt
+++ b/src/XenobladeChroniclesX/Mods/WeatherForceWeather/rules.txt
@@ -25,6 +25,12 @@ condition = $region == 1
 $wtr = 2
 
 [Preset]
+name = "Lightning (unused)"
+category = Weather
+condition = $region == 1
+$wtr = 3
+
+[Preset]
 name = "Heavy Rain"
 category = Weather
 condition = $region == 1
@@ -53,6 +59,18 @@ name = "Rainbow"
 category = Weather
 condition = $region == 1
 $wtr = 8
+
+[Preset]
+name = "Rain (unused)"
+category = Weather
+condition = $region == 1
+$wtr = 9
+
+[Preset]
+name = "Cloudy (unused)"
+category = Weather
+condition = $region == 1
+$wtr = 10
 
 [Preset] ###########################################
 name = "Noctilum"
@@ -117,6 +135,12 @@ condition = $region == 3
 $wtr = 4
 
 [Preset]
+name = "Thunderstorms (unused)"
+category = Weather
+condition = $region == 3
+$wtr = 5
+
+[Preset]
 name = "Electromagnetic Storms"
 category = Weather
 condition = $region == 3
@@ -151,6 +175,12 @@ category = Weather
 condition = $region == 4
 
 [Preset]
+name = "Thunderstorms (unused)"
+category = Weather
+condition = $region == 4
+$wtr = 2
+
+[Preset]
 name = "Rising Energy Mist"
 category = Weather
 condition = $region == 4
@@ -167,6 +197,12 @@ name = "Crimson Aurora"
 category = Weather
 condition = $region == 4
 $wtr = 5
+
+[Preset]
+name = "Brimstone Rain (unused)"
+category = Weather
+condition = $region == 4
+$wtr = 6
 
 [Preset] ###########################################
 name = "Cauldros"
@@ -185,6 +221,12 @@ condition = $region == 5
 $wtr = 2
 
 [Preset]
+name = "Thunderstorms (unused)"
+category = Weather
+condition = $region == 5
+$wtr = 3
+
+[Preset]
 name = "Electromagnetic Storms"
 category = Weather
 condition = $region == 5
@@ -201,3 +243,9 @@ name = "Rainbow"
 category = Weather
 condition = $region == 5
 $wtr = 6
+
+[Preset] ###########################################
+name = "Weather Lock (Locks current weather till you skip travel or die) (Works even when crossing area borders)"
+category = Region
+$region = 6
+$wtr = 0

--- a/src/XenobladeChroniclesX/Mods/WeatherForceWeather/rules.txt
+++ b/src/XenobladeChroniclesX/Mods/WeatherForceWeather/rules.txt
@@ -2,7 +2,7 @@
 titleIds = 0005000010116100,00050000101C4C00,00050000101C4D00
 name = "Force Weather"
 path = "Xenoblade Chronicles X/Mods/Weather/Force Weather"
-description = Force selected weather. Just select a preset and unload/reload the pack.
+description = Force selected weather. Just select a preset and unload/reload the pack.|Weather Lock works even when traveling into different regions.
 version = 6
 
 [Default]
@@ -14,60 +14,60 @@ name = "Primordia"
 category = Region
 
 [Preset]
-name = "Clear"
+name = "Clear [1]"
 category = Weather
 condition = $region == 1
 
 [Preset]
-name = "Rain"
+name = "Rain [2]"
 category = Weather
 condition = $region == 1
 $wtr = 2
 
 [Preset]
-name = "Lightning (unused)"
+name = "Lightning [3] (unused)"
 category = Weather
 condition = $region == 1
 $wtr = 3
 
 [Preset]
-name = "Heavy Rain"
+name = "Heavy Rain [4]"
 category = Weather
 condition = $region == 1
 $wtr = 4
 
 [Preset]
-name = "Thunderstorms"
+name = "Thunderstorms [5]"
 category = Weather
 condition = $region == 1
 $wtr = 5
 
 [Preset]
-name = "Aurora"
+name = "Aurora [6]"
 category = Weather
 condition = $region == 1
 $wtr = 6
 
 [Preset]
-name = "Meteor Showers"
+name = "Meteor Showers [7]"
 category = Weather
 condition = $region == 1
 $wtr = 7
 
 [Preset]
-name = "Rainbow"
+name = "Rainbow [8]"
 category = Weather
 condition = $region == 1
 $wtr = 8
 
 [Preset]
-name = "Rain (unused)"
+name = "Rain [9] (unused)"
 category = Weather
 condition = $region == 1
 $wtr = 9
 
 [Preset]
-name = "Cloudy (unused)"
+name = "Cloudy [10] (unused)"
 category = Weather
 condition = $region == 1
 $wtr = 10
@@ -78,30 +78,30 @@ category = Region
 $region = 2
 
 [Preset]
-name = "Clear"
+name = "Clear [1]"
 category = Weather
 condition = $region == 2
 
 [Preset]
-name = "Dense Fog"
+name = "Dense Fog [2]"
 category = Weather
 condition = $region == 2
 $wtr = 2
 
 [Preset]
-name = "Rain"
+name = "Rain [3]"
 category = Weather
 condition = $region == 2
 $wtr = 3
 
 [Preset]
-name = "Thunderstorms"
+name = "Thunderstorms [4]"
 category = Weather
 condition = $region == 2
 $wtr = 4
 
 [Preset]
-name = "Energy Mist"
+name = "Energy Mist [5]"
 category = Weather
 condition = $region == 2
 $wtr = 5
@@ -112,54 +112,54 @@ category = Region
 $region = 3
 
 [Preset]
-name = "Clear"
+name = "Clear [1]"
 category = Weather
 condition = $region == 3
 
 [Preset]
-name = "Rain"
+name = "Rain [2]"
 category = Weather
 condition = $region == 3
 $wtr = 2
 
 [Preset]
-name = "Heat Wave"
+name = "Heat Wave [3]"
 category = Weather
 condition = $region == 3
 $wtr = 3
 
 [Preset]
-name = "Sandstorms"
+name = "Sandstorms [4]"
 category = Weather
 condition = $region == 3
 $wtr = 4
 
 [Preset]
-name = "Thunderstorms (unused)"
+name = "Thunderstorms [5] (unused)"
 category = Weather
 condition = $region == 3
 $wtr = 5
 
 [Preset]
-name = "Electromagnetic Storms"
+name = "Electromagnetic Storms [6]"
 category = Weather
 condition = $region == 3
 $wtr = 6
 
 [Preset]
-name = "Aurora"
+name = "Aurora [7]"
 category = Weather
 condition = $region == 3
 $wtr = 7
 
 [Preset]
-name = "Meteor Showers"
+name = "Meteor Showers [8]"
 category = Weather
 condition = $region == 3
 $wtr = 8
 
 [Preset]
-name = "Rainbow"
+name = "Rainbow [9]"
 category = Weather
 condition = $region == 3
 $wtr = 9
@@ -170,36 +170,36 @@ category = Region
 $region = 4
 
 [Preset]
-name = "Cloudy"
+name = "Cloudy [1]"
 category = Weather
 condition = $region == 4
 
 [Preset]
-name = "Thunderstorms (unused)"
+name = "Thunderstorms [2] (unused)"
 category = Weather
 condition = $region == 4
 $wtr = 2
 
 [Preset]
-name = "Rising Energy Mist"
+name = "Rising Energy Mist [3]"
 category = Weather
 condition = $region == 4
 $wtr = 3
 
 [Preset]
-name = "Spores"
+name = "Spores [4]"
 category = Weather
 condition = $region == 4
 $wtr = 4
 
 [Preset]
-name = "Crimson Aurora"
+name = "Crimson Aurora [5]"
 category = Weather
 condition = $region == 4
 $wtr = 5
 
 [Preset]
-name = "Brimstone Rain (unused)"
+name = "Brimstone Rain [6] (unused)"
 category = Weather
 condition = $region == 4
 $wtr = 6
@@ -210,42 +210,162 @@ category = Region
 $region = 5
 
 [Preset]
-name = "Clear"
+name = "Clear [1]"
 category = Weather
 condition = $region == 5
 
 [Preset]
-name = "Cloudy"
+name = "Cloudy [2]"
 category = Weather
 condition = $region == 5
 $wtr = 2
 
 [Preset]
-name = "Thunderstorms (unused)"
+name = "Thunderstorms [3] (unused)"
 category = Weather
 condition = $region == 5
 $wtr = 3
 
 [Preset]
-name = "Electromagnetic Storms"
+name = "Electromagnetic Storms [4]"
 category = Weather
 condition = $region == 5
 $wtr = 4
 
 [Preset]
-name = "Brimstone Rain"
+name = "Brimstone Rain [5]"
 category = Weather
 condition = $region == 5
 $wtr = 5
 
 [Preset]
-name = "Rainbow"
+name = "Rainbow [6]"
 category = Weather
 condition = $region == 5
 $wtr = 6
 
 [Preset] ###########################################
-name = "Weather Lock (Locks current weather till you skip travel or die) (Works even when crossing area borders)"
+name = "Weather Lock [0] (Locks current weather till you skip travel or die)"
 category = Region
 $region = 6
 $wtr = 0
+
+###### uncommemt to use different weather in the Barracks
+###[Preset] ###########################################
+###name = "Blade Barracks (unused)"
+###category = Region
+###$region = 7
+
+[Preset]
+name = "Clear [1]"
+category = Weather
+condition = $region == 7
+$wtr = 1
+
+[Preset]
+name = "Sunshower [2]"
+category = Weather
+condition = $region == 7
+$wtr = 2
+
+[Preset]
+name = "Cloudy [3]"
+category = Weather
+condition = $region == 7
+$wtr = 3
+
+[Preset]
+name = "Dense Fog [4]"
+category = Weather
+condition = $region == 7
+$wtr = 4
+
+[Preset]
+name = "Rain [5]"
+category = Weather
+condition = $region == 7
+$wtr = 5
+
+[Preset]
+name = "Lightning [6]"
+category = Weather
+condition = $region == 7
+$wtr = 6
+
+[Preset]
+name = "Heavy Rain [7]"
+category = Weather
+condition = $region == 7
+$wtr = 7
+
+[Preset]
+name = "Heat Wave [8]"
+category = Weather
+condition = $region == 7
+$wtr = 8
+
+[Preset]
+name = "Sandstorms [9]"
+category = Weather
+condition = $region == 7
+$wtr = 9
+
+[Preset]
+name = "Thunderstorms [10]"
+category = Weather
+condition = $region == 7
+$wtr = 10
+
+[Preset]
+name = "Electromagnetic Storms [11]"
+category = Weather
+condition = $region == 7
+$wtr = 11
+
+[Preset]
+name = "Rising Energy Mist [12]"
+category = Weather
+condition = $region == 7
+$wtr = 12
+
+[Preset]
+name = "Energy Mist [13]"
+category = Weather
+condition = $region == 7
+$wtr = 13
+
+[Preset]
+name = "Brimstone Rain [14]"
+category = Weather
+condition = $region == 7
+$wtr = 14
+
+[Preset]
+name = "Spores [15]"
+category = Weather
+condition = $region == 7
+$wtr = 15
+
+[Preset]
+name = "Aurora [16]"
+category = Weather
+condition = $region == 7
+$wtr = 16
+
+[Preset]
+name = "Crimson Aurora [17]"
+category = Weather
+condition = $region == 7
+$wtr = 17
+
+[Preset]
+name = "Meteor Showers [18]"
+category = Weather
+condition = $region == 7
+$wtr = 18
+
+[Preset]
+name = "Rainbow [19]"
+category = Weather
+condition = $region == 7
+$wtr = 19


### PR DESCRIPTION
There were some unused weather conditions that the weather mod could access so I added those. The weather mod can also lock the current weather which can get weather in places its not supposed to be so I added an option for that.

I also fixed 1.0.2J support in the blade point multiplier.
small feature update to global nemesis offline as well

E fix: Was just discovered that Blade missions offline could be used to grief currently active online missions. Added a line in the .asm to kill the online (same as enemy stats mod). Also added troubleshooting text for a common issue that already existed with the mod.


also also, unrelated question to the pull request but in Graphics pack v708, XCX has a brightness fix that seems to work better than the current one. It works better for me than the current one and other people have reported it working better for them. Would it be appropriate for it to ever come back as 'brightness OLD' next to the current brightness fix?