### PR TITLE
[Kirby Rainbow Curse] Add workaround for invisible lines

### DIFF
--- a/Workarounds/KirbyRainbow_InvisibleLineFix/ebdd1eb96ab75207_0000000000000000_vs.txt
+++ b/Workarounds/KirbyRainbow_InvisibleLineFix/ebdd1eb96ab75207_0000000000000000_vs.txt
@@ -1,0 +1,484 @@
+#version 430
+#extension GL_ARB_texture_gather : enable
+#extension GL_ARB_separate_shader_objects : enable
+// shader %08x%08x
+// start of shader inputs/outputs, predetermined by Cemu. Do not touch
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#endif
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[19];
+};
+#else
+uniform ivec4 uf_remappedVS[19];
+#endif
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+};
+layout(location = 1) out vec4 passParameterSem1;
+layout(location = 2) out vec4 passParameterSem2;
+layout(location = 6) out vec4 passParameterSem10;
+layout(location = 0) out vec4 passParameterSem0;
+layout(location = 3) out vec4 passParameterSem6;
+layout(location = 4) out vec4 passParameterSem8;
+layout(location = 5) out vec4 passParameterSem9;
+layout(location = 7) out vec4 passParameterSem12;
+layout(location = 8) out vec4 passParameterSem13;
+// end of shader inputs/outputs
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R2f = vec4(0.0);
+vec4 R3f = vec4(0.0);
+vec4 R4f = vec4(0.0);
+vec4 R5f = vec4(0.0);
+vec4 R6f = vec4(0.0);
+vec4 R7f = vec4(0.0);
+vec4 R8f = vec4(0.0);
+vec4 R9f = vec4(0.0);
+vec4 R10f = vec4(0.0);
+vec4 R11f = vec4(0.0);
+vec4 R12f = vec4(0.0);
+vec4 R13f = vec4(0.0);
+vec4 R122f = vec4(0.0);
+vec4 R123f = vec4(0.0);
+vec4 R124f = vec4(0.0);
+vec4 R125f = vec4(0.0);
+vec4 R126f = vec4(0.0);
+vec4 R127f = vec4(0.0);
+uvec4 attrDecoder;
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = floatBitsToInt(ivec4(gl_VertexID, 0, 0, gl_InstanceID));
+attrDecoder = attrDataSem2;
+attrDecoder = (attrDecoder>>24)|((attrDecoder>>8)&0xFF00)|((attrDecoder<<8)&0xFF0000)|((attrDecoder<<24));
+R3f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(int(attrDecoder.w)));
+attrDecoder = attrDataSem1;
+attrDecoder = (attrDecoder>>24)|((attrDecoder>>8)&0xFF00)|((attrDecoder<<8)&0xFF0000)|((attrDecoder<<24));
+R2f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(int(attrDecoder.w)));
+attrDecoder = attrDataSem3;
+attrDecoder = (attrDecoder>>24)|((attrDecoder>>8)&0xFF00)|((attrDecoder<<8)&0xFF0000)|((attrDecoder<<24));
+R4f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(int(attrDecoder.w)));
+attrDecoder = attrDataSem0;
+attrDecoder = (attrDecoder>>24)|((attrDecoder>>8)&0xFF00)|((attrDecoder<<8)&0xFF0000)|((attrDecoder<<24));
+R1f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(int(attrDecoder.w)));
+// 0
+PV0f.x = mul_nonIEEE(R1f.y, intBitsToFloat(uf_remappedVS[0].x));
+PV0f.y = mul_nonIEEE(R1f.x, intBitsToFloat(uf_remappedVS[0].z));
+PV0f.z = mul_nonIEEE(R1f.z, intBitsToFloat(uf_remappedVS[0].y));
+R7f.w = 1.0;
+R125f.x = R4f.x + -(0.5);
+PS0f = R125f.x;
+// 1
+R127f.x = (mul_nonIEEE(-(R1f.y),intBitsToFloat(uf_remappedVS[0].z)) + PV0f.z);
+PV1f.x = R127f.x;
+R127f.y = (mul_nonIEEE(-(R1f.z),intBitsToFloat(uf_remappedVS[0].x)) + PV0f.y);
+PV1f.y = R127f.y;
+R127f.z = (mul_nonIEEE(-(R1f.x),intBitsToFloat(uf_remappedVS[0].y)) + PV0f.x);
+PV1f.z = R127f.z;
+R125f.w = R4f.z + -(0.5);
+R0f.y = R4f.y + -(0.5);
+PS1f = R0f.y;
+// 2
+tempf.x = dot(vec4(PV1f.x,PV1f.y,PV1f.z,-0.0),vec4(PV1f.x,PV1f.y,PV1f.z,0.0));
+PV0f.x = tempf.x;
+PV0f.y = tempf.x;
+PV0f.z = tempf.x;
+PV0f.w = tempf.x;
+R126f.x = intBitsToFloat(uf_remappedVS[1].z);
+PS0f = R126f.x;
+// 3
+R2f.x = R4f.w + -(0.5);
+R123f.y = (intBitsToFloat(uf_remappedVS[2].z) * intBitsToFloat(0x3e22f983) + 0.5);
+PV1f.y = R123f.y;
+R126f.z = -(R1f.z) * -(R1f.z);
+R123f.w = (intBitsToFloat(uf_remappedVS[3].z) * intBitsToFloat(0x3e22f983) + 0.5);
+PV1f.w = R123f.w;
+tempResultf = 1.0 / sqrt(PV0f.x);
+PS1f = tempResultf;
+// 4
+R4f.x = mul_nonIEEE(R127f.y, PS1f);
+PV0f.x = R4f.x;
+R5f.y = mul_nonIEEE(R127f.x, PS1f);
+PV0f.y = R5f.y;
+PV0f.z = fract(PV1f.w);
+R126f.w = mul_nonIEEE(R127f.z, PS1f);
+PV0f.w = R126f.w;
+R127f.x = fract(PV1f.y);
+PS0f = R127f.x;
+// 5
+R123f.x = (-(R1f.y) * -(R1f.y) + R126f.z);
+PV1f.x = R123f.x;
+PV1f.y = mul_nonIEEE(R2f.w, PV0f.x);
+PV1f.y /= 2.0;
+PV1f.z = mul_nonIEEE(R2f.w, PV0f.y);
+PV1f.z /= 2.0;
+PV1f.w = mul_nonIEEE(R2f.w, PV0f.w);
+PV1f.w /= 2.0;
+R127f.y = (PV0f.z * intBitsToFloat(0x40c90fdb) + intBitsToFloat(0xc0490fdb));
+PS1f = R127f.y;
+// 6
+R7f.x = R3f.x + -(PV1f.z);
+PV0f.x = R7f.x;
+R12f.y = R3f.y + -(PV1f.y);
+PV0f.y = R12f.y;
+R2f.z = R3f.z + -(PV1f.w);
+PV0f.z = R2f.z;
+R123f.w = (-(R1f.x) * -(R1f.x) + PV1f.x);
+PV0f.w = R123f.w;
+R127f.w = (R127f.x * intBitsToFloat(0x40c90fdb) + intBitsToFloat(0xc0490fdb));
+PS0f = R127f.w;
+// 7
+tempf.x = dot(vec4(PV0f.x,PV0f.y,PV0f.z,R7f.w),vec4(intBitsToFloat(uf_remappedVS[4].x),intBitsToFloat(uf_remappedVS[4].y),intBitsToFloat(uf_remappedVS[4].z),intBitsToFloat(uf_remappedVS[4].w)));
+PV1f.x = tempf.x;
+PV1f.y = tempf.x;
+PV1f.z = tempf.x;
+PV1f.w = tempf.x;
+R10f.w = tempf.x;
+tempResultf = 1.0 / sqrt(PV0f.w);
+R125f.z = tempResultf;
+PS1f = R125f.z;
+// 8
+R5f.x = dot(vec4(R7f.x,R12f.y,R2f.z,R7f.w),vec4(intBitsToFloat(uf_remappedVS[5].x),intBitsToFloat(uf_remappedVS[5].y),intBitsToFloat(uf_remappedVS[5].z),intBitsToFloat(uf_remappedVS[5].w)));
+PV0f.x = R5f.x;
+PV0f.y = R5f.x;
+PV0f.z = R5f.x;
+PV0f.w = R5f.x;
+PS0f = 1.0 / PV1f.x;
+// 9
+R127f.x = R127f.y * intBitsToFloat(0x3e22f983);
+PV1f.x = R127f.x;
+R127f.y = mul_nonIEEE(-(R1f.z), R125f.z);
+R126f.z = R127f.w * intBitsToFloat(0x3e22f983);
+PV1f.w = PV0f.x * PS0f;
+R127f.w = intBitsToFloat(uf_remappedVS[6].z);
+PS1f = R127f.w;
+// 10
+R0f.x = mul_nonIEEE(-(R1f.y), R125f.z);
+R6f.y = -(PV1f.w) + 1.0;
+R127f.z = intBitsToFloat(uf_remappedVS[7].z);
+R4f.w = intBitsToFloat(uf_remappedVS[1].y);
+R0f.w = sin((PV1f.x)/0.1591549367);
+PS0f = R0f.w;
+// 11
+R10f.x = dot(vec4(R7f.x,R12f.y,R2f.z,R7f.w),vec4(intBitsToFloat(uf_remappedVS[8].x),intBitsToFloat(uf_remappedVS[8].y),intBitsToFloat(uf_remappedVS[8].z),intBitsToFloat(uf_remappedVS[8].w)));
+PV1f.x = R10f.x;
+PV1f.y = R10f.x;
+PV1f.z = R10f.x;
+PV1f.w = R10f.x;
+R124f.z = cos((R127f.x)/0.1591549367);
+PS1f = R124f.z;
+// 12
+tempf.x = dot(vec4(R7f.x,R12f.y,R2f.z,R7f.w),vec4(intBitsToFloat(uf_remappedVS[9].x),intBitsToFloat(uf_remappedVS[9].y),intBitsToFloat(uf_remappedVS[9].z),intBitsToFloat(uf_remappedVS[9].w)));
+PV0f.x = tempf.x;
+PV0f.y = tempf.x;
+PV0f.z = tempf.x;
+PV0f.w = tempf.x;
+R10f.y = tempf.x;
+R4f.y = sin((R126f.z)/0.1591549367);
+PS0f = R4f.y;
+// 13
+tempf.x = dot(vec4(intBitsToFloat(uf_remappedVS[0].x),intBitsToFloat(uf_remappedVS[0].y),intBitsToFloat(uf_remappedVS[0].z),-0.0),vec4(intBitsToFloat(uf_remappedVS[0].x),intBitsToFloat(uf_remappedVS[0].y),intBitsToFloat(uf_remappedVS[0].z),0.0));
+PV1f.x = tempf.x;
+PV1f.y = tempf.x;
+PV1f.z = tempf.x;
+PV1f.w = tempf.x;
+R127f.x = cos((R126f.z)/0.1591549367);
+PS1f = R127f.x;
+// 14
+R124f.x = mul_nonIEEE(R126f.w, R127f.w);
+R124f.y = intBitsToFloat(uf_remappedVS[7].y);
+R4f.z = intBitsToFloat(uf_remappedVS[6].y);
+R2f.w = mul_nonIEEE(R126f.w, R126f.x);
+tempResultf = 1.0 / sqrt(PV1f.x);
+R124f.w = tempResultf;
+PS0f = R124f.w;
+// 15
+PV1f.x = mul_nonIEEE(intBitsToFloat(uf_remappedVS[0].z), PS0f);
+R126f.y = mul_nonIEEE(intBitsToFloat(uf_remappedVS[0].y), PS0f);
+R126f.z = mul_nonIEEE(R126f.w, R127f.z);
+R126f.w = mul_nonIEEE(R127f.y, R126f.x);
+R125f.y = mul_nonIEEE(R127f.y, R127f.w);
+PS1f = R125f.y;
+// 16
+backupReg0f = R126f.x;
+backupReg1f = R127f.y;
+backupReg2f = R127f.z;
+backupReg2f = R127f.z;
+R126f.x = mul_nonIEEE(PV1f.x, R127f.w);
+R127f.y = mul_nonIEEE(PV1f.x, backupReg0f);
+R127f.z = mul_nonIEEE(backupReg1f, backupReg2f);
+R127f.w = mul_nonIEEE(PV1f.x, backupReg2f);
+R5f.w = mul_nonIEEE(R124f.z, R125f.x);
+PS0f = R5f.w;
+// 17
+PV1f.x = mul_nonIEEE(R0f.w, R125f.x);
+R2f.y = mul_nonIEEE(R127f.x, R125f.w);
+PV1f.z = mul_nonIEEE(R4f.y, R125f.w);
+R125f.w = mul_nonIEEE(intBitsToFloat(uf_remappedVS[0].x), R124f.w);
+R8f.y = mul_nonIEEE(-(R1f.x), R125f.z);
+PS1f = R8f.y;
+// 18
+backupReg0f = R127f.x;
+R127f.x = (mul_nonIEEE(backupReg0f,R2f.x) + PV1f.z);
+R7f.y = intBitsToFloat(uf_remappedVS[6].x);
+R0f.z = intBitsToFloat(uf_remappedVS[1].x);
+R6f.w = (mul_nonIEEE(R124f.z,R0f.y) + PV1f.x);
+R124f.z = (mul_nonIEEE(R126f.y,R4f.w) + R127f.y);
+PS0f = R124f.z;
+// 19
+R6f.x = intBitsToFloat(uf_remappedVS[7].x);
+R123f.y = (mul_nonIEEE(R126f.y,R4f.z) + R126f.x);
+PV1f.y = R123f.y;
+R125f.z = (mul_nonIEEE(R126f.y,R124f.y) + R127f.w);
+R127f.w = (mul_nonIEEE(R4f.x,R4f.w) + R2f.w);
+R124f.w = (mul_nonIEEE(R4f.x,R4f.z) + R124f.x);
+PS1f = R124f.w;
+// 20
+backupReg0f = R0f.x;
+backupReg0f = R0f.x;
+backupReg0f = R0f.x;
+backupReg1f = R4f.z;
+R0f.x = (mul_nonIEEE(backupReg0f,R4f.w) + R126f.w);
+R9f.y = (mul_nonIEEE(backupReg0f,R124f.y) + R127f.z);
+R4f.z = (mul_nonIEEE(backupReg0f,backupReg1f) + R125f.y);
+R126f.w = (mul_nonIEEE(R4f.x,R124f.y) + R126f.z);
+R13f.y = (mul_nonIEEE(R125f.w,R7f.y) + PV1f.y);
+PS0f = R13f.y;
+// 21
+backupReg0f = R2f.x;
+backupReg1f = R0f.y;
+R2f.x = (mul_nonIEEE(-(R4f.y),backupReg0f) + R2f.y);
+R0f.y = (mul_nonIEEE(R125f.w,R0f.z) + R124f.z);
+R123f.z = (mul_nonIEEE(-(R0f.w),backupReg1f) + R5f.w);
+PV1f.z = R123f.z;
+R123f.w = (mul_nonIEEE(intBitsToFloat(uf_remappedVS[2].y),R127f.x) + intBitsToFloat(uf_remappedVS[10].w));
+PV1f.w = R123f.w;
+R5f.z = (mul_nonIEEE(R125f.w,R6f.x) + R125f.z);
+PS1f = R5f.z;
+// 22
+backupReg0f = R5f.y;
+backupReg0f = R5f.y;
+R8f.x = (mul_nonIEEE(R5f.y,R0f.z) + R127f.w);
+R5f.y = (mul_nonIEEE(backupReg0f,R7f.y) + R124f.w);
+R6f.z = (mul_nonIEEE(backupReg0f,R6f.x) + R126f.w);
+R0f.w = (mul_nonIEEE(intBitsToFloat(uf_remappedVS[3].x),PV1f.z) + intBitsToFloat(uf_remappedVS[10].x));
+R11f.w = PV1f.w + 0.5;
+PS0f = R11f.w;
+// 0
+backupReg0f = R0f.x;
+PV0f.x = mul_nonIEEE(R6f.y, intBitsToFloat(uf_remappedVS[11].z));
+R6f.y = (mul_nonIEEE(R8f.y,R0f.z) + backupReg0f);
+R0f.z = (mul_nonIEEE(R8f.y,R7f.y) + R4f.z);
+R4f.x = intBitsToFloat(uf_remappedVS[12].x);
+PS0f = R4f.x;
+// 1
+backupReg0f = R5f.x;
+R5f.x = (mul_nonIEEE(R8f.y,R6f.x) + R9f.y);
+R123f.y = (mul_nonIEEE(intBitsToFloat(uf_remappedVS[3].y),R6f.w) + intBitsToFloat(uf_remappedVS[10].y));
+PV1f.y = R123f.y;
+R10f.z = backupReg0f + -(PV0f.x);
+R11f.x = R0f.w + 0.5;
+PS1f = R11f.x;
+// 2
+R11f.y = PV1f.y + 0.5;
+R123f.w = (mul_nonIEEE(intBitsToFloat(uf_remappedVS[2].x),R2f.x) + intBitsToFloat(uf_remappedVS[10].z));
+PV0f.w = R123f.w;
+// 3
+R4f.y = intBitsToFloat(uf_remappedVS[12].y);
+R4f.z = intBitsToFloat(uf_remappedVS[12].z);
+R4f.w = mul_nonIEEE(R3f.w, intBitsToFloat(uf_remappedVS[12].w));
+R11f.z = PV0f.w + 0.5;
+PS1f = R11f.z;
+// 4
+backupReg0f = R1f.w;
+R1f.xyz = vec3(intBitsToFloat(uf_remappedVS[13].x),intBitsToFloat(uf_remappedVS[13].y),intBitsToFloat(uf_remappedVS[13].z));
+R1f.w = mul_nonIEEE(backupReg0f, intBitsToFloat(uf_remappedVS[13].w));
+// export
+R10f.z = 0.5; /* workaround */
+SET_POSITION(vec4(R10f.x, R10f.y, R10f.z, R10f.w));
+// export
+passParameterSem1 = vec4(R4f.x, R4f.y, R4f.z, R4f.w);
+// export
+passParameterSem2 = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+// export
+passParameterSem10 = vec4(R11f.x, R11f.y, R11f.z, R11f.w);
+// 0
+tempf.x = dot(vec4(intBitsToFloat(uf_remappedVS[14].x),intBitsToFloat(uf_remappedVS[14].y),intBitsToFloat(uf_remappedVS[14].z),-0.0),vec4(intBitsToFloat(uf_remappedVS[14].x),intBitsToFloat(uf_remappedVS[14].y),intBitsToFloat(uf_remappedVS[14].z),0.0));
+PV0f.x = tempf.x;
+PV0f.y = tempf.x;
+PV0f.z = tempf.x;
+PV0f.w = tempf.x;
+// 1
+tempf.x = dot(vec4(intBitsToFloat(uf_remappedVS[15].x),intBitsToFloat(uf_remappedVS[15].y),intBitsToFloat(uf_remappedVS[15].z),-0.0),vec4(intBitsToFloat(uf_remappedVS[15].x),intBitsToFloat(uf_remappedVS[15].y),intBitsToFloat(uf_remappedVS[15].z),0.0));
+PV1f.x = tempf.x;
+PV1f.y = tempf.x;
+PV1f.z = tempf.x;
+PV1f.w = tempf.x;
+tempResultf = 1.0 / sqrt(PV0f.x);
+PS1f = tempResultf;
+// 2
+R125f.x = mul_nonIEEE(intBitsToFloat(uf_remappedVS[14].x), PS1f);
+R124f.y = mul_nonIEEE(intBitsToFloat(uf_remappedVS[14].y), PS1f);
+R125f.z = mul_nonIEEE(intBitsToFloat(uf_remappedVS[14].z), PS1f);
+tempResultf = 1.0 / sqrt(PV1f.x);
+PS0f = tempResultf;
+// 3
+R11f.x = mul_nonIEEE(intBitsToFloat(uf_remappedVS[15].x), PS0f);
+R126f.y = mul_nonIEEE(intBitsToFloat(uf_remappedVS[15].y), PS0f);
+R124f.z = mul_nonIEEE(intBitsToFloat(uf_remappedVS[15].z), PS0f);
+// 4
+R1f.x = dot(vec4(R7f.x,R12f.y,R2f.z,R7f.w),vec4(intBitsToFloat(uf_remappedVS[16].x),intBitsToFloat(uf_remappedVS[16].y),intBitsToFloat(uf_remappedVS[16].z),intBitsToFloat(uf_remappedVS[16].w)));
+PV0f.x = R1f.x;
+PV0f.y = R1f.x;
+PV0f.z = R1f.x;
+PV0f.w = R1f.x;
+R127f.x = mul_nonIEEE(R5f.z, intBitsToFloat(uf_remappedVS[16].z));
+PS0f = R127f.x;
+// 5
+tempf.x = dot(vec4(R7f.x,R12f.y,R2f.z,R7f.w),vec4(intBitsToFloat(uf_remappedVS[17].x),intBitsToFloat(uf_remappedVS[17].y),intBitsToFloat(uf_remappedVS[17].z),intBitsToFloat(uf_remappedVS[17].w)));
+PV1f.x = tempf.x;
+PV1f.y = tempf.x;
+PV1f.z = tempf.x;
+PV1f.w = tempf.x;
+R1f.y = tempf.x;
+R126f.x = mul_nonIEEE(R5f.z, intBitsToFloat(uf_remappedVS[17].z));
+PS1f = R126f.x;
+// 6
+tempf.x = dot(vec4(R7f.x,R12f.y,R2f.z,R7f.w),vec4(intBitsToFloat(uf_remappedVS[18].x),intBitsToFloat(uf_remappedVS[18].y),intBitsToFloat(uf_remappedVS[18].z),intBitsToFloat(uf_remappedVS[18].w)));
+PV0f.x = tempf.x;
+PV0f.y = tempf.x;
+PV0f.z = tempf.x;
+PV0f.w = tempf.x;
+R1f.z = tempf.x;
+R124f.x = mul_nonIEEE(R5f.z, intBitsToFloat(uf_remappedVS[18].z));
+PS0f = R124f.x;
+// 7
+R2f.x = dot(vec4(R0f.y,R13f.y,R127f.x,-0.0),vec4(intBitsToFloat(uf_remappedVS[16].x),intBitsToFloat(uf_remappedVS[16].y),1.0,0.0));
+PV1f.x = R2f.x;
+PV1f.y = R2f.x;
+PV1f.z = R2f.x;
+PV1f.w = R2f.x;
+R122f.x = (mul_nonIEEE(R13f.y,intBitsToFloat(uf_remappedVS[17].y)) + R126f.x);
+PS1f = R122f.x;
+// 8
+backupReg0f = R0f.z;
+R123f.x = (mul_nonIEEE(R13f.y,intBitsToFloat(uf_remappedVS[18].y)) + R124f.x);
+PV0f.x = R123f.x;
+R2f.y = (mul_nonIEEE(R0f.y,intBitsToFloat(uf_remappedVS[17].x)) + PS1f);
+PV0f.z = mul_nonIEEE(R5f.y, intBitsToFloat(uf_remappedVS[18].y));
+PV0f.w = mul_nonIEEE(backupReg0f, intBitsToFloat(uf_remappedVS[17].y));
+PS0f = mul_nonIEEE(R5f.y, intBitsToFloat(uf_remappedVS[17].y));
+// 9
+R124f.x = (mul_nonIEEE(R6f.z,intBitsToFloat(uf_remappedVS[17].z)) + PS0f);
+R125f.y = (mul_nonIEEE(R5f.x,intBitsToFloat(uf_remappedVS[17].z)) + PV0f.w);
+R2f.z = (mul_nonIEEE(R0f.y,intBitsToFloat(uf_remappedVS[18].x)) + PV0f.x);
+R127f.w = mul_nonIEEE(R0f.z, intBitsToFloat(uf_remappedVS[18].y));
+R127f.x = (mul_nonIEEE(R8f.x,intBitsToFloat(uf_remappedVS[18].x)) + PV0f.z);
+PS1f = R127f.x;
+// 10
+R13f.x = dot(vec4(R8f.x,R5f.y,R6f.z,-0.0),vec4(intBitsToFloat(uf_remappedVS[16].x),intBitsToFloat(uf_remappedVS[16].y),intBitsToFloat(uf_remappedVS[16].z),0.0));
+PV0f.x = R13f.x;
+PV0f.y = R13f.x;
+PV0f.z = R13f.x;
+PV0f.w = R13f.x;
+PS0f = mul_nonIEEE(R5f.x, intBitsToFloat(uf_remappedVS[16].z));
+// 11
+R0f.x = dot(vec4(R6f.y,R0f.z,PS0f,-0.0),vec4(intBitsToFloat(uf_remappedVS[16].x),intBitsToFloat(uf_remappedVS[16].y),1.0,0.0));
+PV1f.x = R0f.x;
+PV1f.y = R0f.x;
+PV1f.z = R0f.x;
+PV1f.w = R0f.x;
+R13f.y = (mul_nonIEEE(R8f.x,intBitsToFloat(uf_remappedVS[17].x)) + R124f.x);
+PS1f = R13f.y;
+// 12
+R123f.x = (mul_nonIEEE(R5f.x,intBitsToFloat(uf_remappedVS[18].z)) + R127f.w);
+PV0f.x = R123f.x;
+R0f.y = (mul_nonIEEE(R6f.y,intBitsToFloat(uf_remappedVS[17].x)) + R125f.y);
+R13f.z = (mul_nonIEEE(R6f.z,intBitsToFloat(uf_remappedVS[18].z)) + R127f.x);
+PV0f.w = mul_nonIEEE(intBitsToFloat(uf_remappedVS[18].z), -(R125f.z));
+PS0f = mul_nonIEEE(intBitsToFloat(uf_remappedVS[17].y), -(R124f.y));
+// 13
+R127f.x = (mul_nonIEEE(intBitsToFloat(uf_remappedVS[17].z),-(R125f.z)) + PS0f);
+R125f.y = mul_nonIEEE(intBitsToFloat(uf_remappedVS[17].z), -(R124f.z));
+R0f.z = (mul_nonIEEE(R6f.y,intBitsToFloat(uf_remappedVS[18].x)) + PV0f.x);
+R127f.w = mul_nonIEEE(intBitsToFloat(uf_remappedVS[18].y), -(R126f.y));
+R124f.x = (mul_nonIEEE(intBitsToFloat(uf_remappedVS[18].y),-(R124f.y)) + PV0f.w);
+PS1f = R124f.x;
+// 14
+R5f.x = dot(vec4(intBitsToFloat(uf_remappedVS[16].x),intBitsToFloat(uf_remappedVS[16].y),intBitsToFloat(uf_remappedVS[16].z),-0.0),vec4(-(R125f.x),-(R124f.y),-(R125f.z),0.0));
+PV0f.x = R5f.x;
+PV0f.y = R5f.x;
+PV0f.z = R5f.x;
+PV0f.w = R5f.x;
+R126f.x = mul_nonIEEE(intBitsToFloat(uf_remappedVS[16].z), -(R124f.z));
+PS0f = R126f.x;
+// 15
+R123f.x = (mul_nonIEEE(intBitsToFloat(uf_remappedVS[17].y),-(R126f.y)) + R125f.y);
+PV1f.x = R123f.x;
+R5f.y = (mul_nonIEEE(intBitsToFloat(uf_remappedVS[17].x),-(R125f.x)) + R127f.x);
+R5f.z = (mul_nonIEEE(intBitsToFloat(uf_remappedVS[18].x),-(R125f.x)) + R124f.x);
+// 16
+R6f.x = dot(vec4(intBitsToFloat(uf_remappedVS[16].x),intBitsToFloat(uf_remappedVS[16].y),R126f.x,-0.0),vec4(-(R11f.x),-(R126f.y),1.0,0.0));
+PV0f.x = R6f.x;
+PV0f.y = R6f.x;
+PV0f.z = R6f.x;
+PV0f.w = R6f.x;
+R6f.y = (mul_nonIEEE(intBitsToFloat(uf_remappedVS[17].x),-(R11f.x)) + PV1f.x);
+PS0f = R6f.y;
+// 17
+tempf.x = dot(vec4(intBitsToFloat(uf_remappedVS[18].x),intBitsToFloat(uf_remappedVS[18].z),R127f.w,-0.0),vec4(-(R11f.x),-(R124f.z),1.0,0.0));
+PV1f.x = tempf.x;
+PV1f.y = tempf.x;
+PV1f.z = tempf.x;
+PV1f.w = tempf.x;
+R6f.z = tempf.x;
+// export
+passParameterSem0 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
+// export
+passParameterSem6 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
+// export
+passParameterSem8 = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+// export
+passParameterSem9 = vec4(R13f.x, R13f.y, R13f.z, R13f.w);
+// export
+passParameterSem12 = vec4(R6f.x, R6f.y, R6f.z, R6f.w);
+// export
+passParameterSem13 = vec4(R5f.x, R5f.y, R5f.z, R5f.w);
+}

--- a/Workarounds/KirbyRainbow_InvisibleLineFix/rules.txt
+++ b/Workarounds/KirbyRainbow_InvisibleLineFix/rules.txt
@@ -1,0 +1,7 @@
+[Definition]
+titleIds = 00050000101ABC00,00050000101B5100,0005000010188B00
+name = Workaround for invisible rainbow lines
+path = "Kirby and the Rainbow Curse & Paintbrush/Workarounds/Fix invisible lines"
+description = Fixes a bug which causes painted rainbow lines to become randomly invisible.
+version = 7
+default = 1


### PR DESCRIPTION
Occasionally the z component of gl_Position gets set to -175 which then causes the line to get clipped. As a workaround we always force z to 0.5 (the expected value)