### PR TITLE
[WWHD] Add 16:10 Steam Deck resolution with correct HUD and menus

### DIFF
--- a/Resolutions/WindWakerHD_Resolution/patches.txt
+++ b/Resolutions/WindWakerHD_Resolution/patches.txt
@@ -1,17 +1,17 @@
 [WWHDAspectEUR]
 moduleMatches = 0xB7E748DE
-0x1004AAF0 = .float ($aspectRatio)
-0x101417E0 = .float ($aspectRatio)
-0x101658A8 = .float ($aspectRatio)
+0x1004AAF0 = .float ($aspectRatioWorld) # 3D world
+0x101417E0 = .float ($aspectRatioUI)    # HUD / UI
+0x101658A8 = .float ($aspectRatioWorld) # Effects
 
 [WWHDAspectJAP]
 moduleMatches = 0x74BD3F6A
-0x1004AAF0 = .float ($aspectRatio)
-0x101417F8 = .float ($aspectRatio)
-0x101658C0 = .float ($aspectRatio)
+0x1004AAF0 = .float ($aspectRatioWorld) # 3D world
+0x101417F8 = .float ($aspectRatioUI)    # HUD / UI
+0x101658C0 = .float ($aspectRatioWorld) # Effects
 
 [WWHDAspectUSA]
 moduleMatches = 0x475BD29F
-0x1004AAF0 = .float ($aspectRatio)
-0x101417D0 = .float ($aspectRatio)
-0x10165898 = .float ($aspectRatio)
+0x1004AAF0 = .float ($aspectRatioWorld) # 3D world
+0x101417D0 = .float ($aspectRatioUI)    # HUD / UI
+0x10165898 = .float ($aspectRatioWorld) # Effects

--- a/Resolutions/WindWakerHD_Resolution/rules.txt
+++ b/Resolutions/WindWakerHD_Resolution/rules.txt
@@ -2,7 +2,7 @@
 titleIds = 0005000010143400,0005000010143600,0005000010143500
 name = Resolution
 path = "The Legend of Zelda: The Wind Waker HD/Graphics/Resolution"
-description = Changes the resolution of the game. Made by getdls and Morph.
+description = Changes the resolution of the game. Made by getdls and Morph. 16:10 by Depende3k.
 version = 4
 
 [Preset]
@@ -13,7 +13,8 @@ $gameWidth = 1920
 $gameHeight = 1080
 $lightSource = 1.0
 $scaleShader = 1.0
-$aspectRatio = (16.0/9.0)
+$aspectRatioWorld = (16.0/9.0)
+$aspectRatioUI = (16.0/9.0)
 
 [Preset]
 name = 320x180
@@ -23,7 +24,8 @@ $gameWidth = 1920
 $gameHeight = 1080
 $lightSource = 1.0
 $scaleShader = 1.0
-$aspectRatio = (16.0/9.0)
+$aspectRatioWorld = (16.0/9.0)
+$aspectRatioUI = (16.0/9.0)
 
 [Preset]
 name = 640x360
@@ -33,7 +35,8 @@ $gameWidth = 1920
 $gameHeight = 1080
 $lightSource = 1.0
 $scaleShader = 1.0
-$aspectRatio = (16.0/9.0)
+$aspectRatioWorld = (16.0/9.0)
+$aspectRatioUI = (16.0/9.0)
 
 [Preset]
 name = 960x540
@@ -43,7 +46,8 @@ $gameWidth = 1920
 $gameHeight = 1080
 $lightSource = 1.0
 $scaleShader = 1.0
-$aspectRatio = (16.0/9.0)
+$aspectRatioWorld = (16.0/9.0)
+$aspectRatioUI = (16.0/9.0)
 
 [Preset]
 name = 1280x720
@@ -53,7 +57,8 @@ $gameWidth = 1920
 $gameHeight = 1080
 $lightSource = 1.0
 $scaleShader = 1.0
-$aspectRatio = (16.0/9.0)
+$aspectRatioWorld = (16.0/9.0)
+$aspectRatioUI = (16.0/9.0)
 
 [Preset]
 name = 1600x900
@@ -63,7 +68,8 @@ $gameWidth = 1920
 $gameHeight = 1080
 $lightSource = 1.0
 $scaleShader = 1.0
-$aspectRatio = (16.0/9.0)
+$aspectRatioWorld = (16.0/9.0)
+$aspectRatioUI = (16.0/9.0)
 
 [Preset]
 name = 2560x1440
@@ -73,7 +79,8 @@ $gameWidth = 1920
 $gameHeight = 1080
 $lightSource = 1.0
 $scaleShader = 1.0
-$aspectRatio = (16.0/9.0)
+$aspectRatioWorld = (16.0/9.0)
+$aspectRatioUI = (16.0/9.0)
 
 [Preset]
 name = 2732x1536
@@ -83,7 +90,8 @@ $gameWidth = 1920
 $gameHeight = 1080
 $lightSource = 1.0
 $scaleShader = 1.0
-$aspectRatio = (16.0/9.0)
+$aspectRatioWorld = (16.0/9.0)
+$aspectRatioUI = (16.0/9.0)
 
 [Preset]
 name = 3200x1800
@@ -93,7 +101,8 @@ $gameWidth = 1920
 $gameHeight = 1080
 $lightSource = 1.0
 $scaleShader = 1.0
-$aspectRatio = (16.0/9.0)
+$aspectRatioWorld = (16.0/9.0)
+$aspectRatioUI = (16.0/9.0)
 
 [Preset]
 name = 3840x2160
@@ -103,7 +112,8 @@ $gameWidth = 1920
 $gameHeight = 1080
 $lightSource = 1.0
 $scaleShader = 1.0
-$aspectRatio = (16.0/9.0)
+$aspectRatioWorld = (16.0/9.0)
+$aspectRatioUI = (16.0/9.0)
 
 [Preset]
 name = 5120x2880
@@ -113,7 +123,8 @@ $gameWidth = 1920
 $gameHeight = 1080
 $lightSource = 1.0
 $scaleShader = 1.0
-$aspectRatio = (16.0/9.0)
+$aspectRatioWorld = (16.0/9.0)
+$aspectRatioUI = (16.0/9.0)
 
 [Preset]
 name = 7680x4320
@@ -123,13 +134,36 @@ $gameWidth = 1920
 $gameHeight = 1080
 $lightSource = 1.0
 $scaleShader = 1.0
-$aspectRatio = (16.0/9.0)
-
+$aspectRatioWorld = (16.0/9.0)
+$aspectRatioUI = (16.0/9.0)
 
 #Resolutions						|Aspect ratio
 #2560×1080, 5120×2160, 8192×3456	|64:27 (2.370)
 #3440×1440							|43:18 (2.38)
 #1920×800, 3840×1600, 7680×3200		|12:5 (2.4)
+#1280×800                   		|16:10 (1.5)
+
+[Preset]
+name = ---- Steam Deck 16:10 ----
+$width      = 1280
+$height     = 800
+$gameWidth  = 1280
+$gameHeight = 800
+$lightSource  = 1.0
+$scaleShader = 1.0
+$aspectRatioWorld = (16.0/10.0)
+$aspectRatioUI = (16.0/9.0)
+
+[Preset]
+name = 1280x800 (16:10)
+$width      = 1280
+$height     = 800
+$gameWidth  = 1280
+$gameHeight = 800
+$lightSource  = 1.0
+$scaleShader = 1.0
+$aspectRatioWorld = (16.0/10.0)
+$aspectRatioUI = (16.0/9.0)
 
 [Preset]
 name = ---- Ultra wide 21:9 ----
@@ -139,7 +173,8 @@ $gameWidth= 1920
 $gameHeight= 1080
 $lightSource = 2.0
 $scaleShader = (1920.0/2560.0)
-$aspectRatio = (64.0/27.0) #LG
+$aspectRatioWorld = (64.0/27.0) #LG
+$aspectRatioUI = (64.0/27.0) #LG
 
 [Preset]
 name = 2560x1080 (21:9 HD)
@@ -149,7 +184,8 @@ $gameWidth= 1920
 $gameHeight= 1080
 $lightSource = 2.0
 $scaleShader = (1920.0/2560.0)
-$aspectRatio = (64.0/27.0) #LG
+$aspectRatioWorld = (64.0/27.0) #LG
+$aspectRatioUI = (64.0/27.0) #LG
 
 [Preset]
 name = 3440x1440 (21:9)
@@ -159,7 +195,8 @@ $gameWidth= 1920
 $gameHeight= 1080
 $lightSource = 1.5
 $scaleShader = (2560.0/3440.0)
-$aspectRatio = (43.0/18.0)
+$aspectRatioWorld = (43.0/18.0)
+$aspectRatioUI = (43.0/18.0)
 
 [Preset]
 name = 3840x1600 (21:9)
@@ -169,7 +206,8 @@ $gameWidth= 1920
 $gameHeight= 1080
 $lightSource = 1.35
 $scaleShader = (2844.445/3840.0)
-$aspectRatio = (12.0/5.0)
+$aspectRatioWorld = (12.0/5.0)
+$aspectRatioUI = (12.0/5.0)
 
 [Preset]
 name = 5160x2160 (4k 21:9)
@@ -179,7 +217,8 @@ $gameWidth= 1920
 $gameHeight= 1080
 $lightSource = 1.0
 $scaleShader = (3840.0/5160.0)
-$aspectRatio = (64.0/27.0) #LG
+$aspectRatioWorld = (64.0/27.0) #LG
+$aspectRatioUI = (64.0/27.0) #LG
 
 [Preset]
 name = ---- Superwide 32:9 ----
@@ -189,7 +228,8 @@ $gameWidth= 1920
 $gameHeight= 1080
 $lightSource = 1.5
 $scaleShader = (2560.0/5120.0)
-$aspectRatio = (96.0/27.0)
+$aspectRatioWorld = (96.0/27.0)
+$aspectRatioUI = (96.0/27.0)
 
 [Preset]
 name = 5120x1440 (32:9)
@@ -199,7 +239,8 @@ $gameWidth= 1920
 $gameHeight= 1080
 $lightSource = 1.5
 $scaleShader = (2560.0/5120.0)
-$aspectRatio = (96.0/27.0)
+$aspectRatioWorld = (96.0/27.0)
+$aspectRatioUI = (96.0/27.0)
 
 [Preset]
 name = 7680x2160 (4k 32:9)
@@ -209,7 +250,8 @@ $gameWidth= 1920
 $gameHeight= 1080
 $lightSource = 1.0
 $scaleShader = (3840.0/7680.0)
-$aspectRatio = (96.0/27.0)
+$aspectRatioWorld = (96.0/27.0)
+$aspectRatioUI = (96.0/27.0)
 
 [Preset]
 name = ---- Custom resolutions ----
@@ -219,7 +261,8 @@ $gameWidth = 1920
 $gameHeight = 1080
 $lightSource = 2.0
 $scaleShader = 1.0
-$aspectRatio = (16.0/9.0)
+$aspectRatioWorld = (16.0/9.0)
+$aspectRatioUI = (16.0/9.0)
 
 [Preset]
 name = 1920x1080 AO fix - Light res x2
@@ -229,7 +272,8 @@ $gameWidth = 1920
 $gameHeight = 1080
 $lightSource = 2.0
 $scaleShader = 1.0
-$aspectRatio = (16.0/9.0)
+$aspectRatioWorld = (16.0/9.0)
+$aspectRatioUI = (16.0/9.0)
 
 [Preset]
 name = 2560x1440 AO fix
@@ -239,7 +283,8 @@ $gameWidth = 1920
 $gameHeight = 1080
 $lightSource = 1.5
 $scaleShader = 1.0 #(1088.0/1440.0)
-$aspectRatio = (16.0/9.0)
+$aspectRatioWorld = (16.0/9.0)
+$aspectRatioUI = (16.0/9.0)
 
 [Preset]
 name = 3840x2160 AO fix - light res x2
@@ -249,7 +294,8 @@ $gameWidth = 1920
 $gameHeight = 1080
 $lightSource = 2.0
 $scaleShader = 1.0
-$aspectRatio = (16.0/9.0)
+$aspectRatioWorld = (16.0/9.0)
+$aspectRatioUI = (16.0/9.0)
 
 [Preset]
 name = 1920x2160 vert x2 SSAA - light res x2
@@ -259,7 +305,8 @@ $gameWidth = 1920
 $gameHeight = 1080
 $lightSource = 2.0
 $scaleShader = 1.0
-$aspectRatio = (16.0/9.0)
+$aspectRatioWorld = (16.0/9.0)
+$aspectRatioUI = (16.0/9.0)
 
 [Preset]
 name = 3840x4320 vert x2 SSAA - light res x2
@@ -269,7 +316,8 @@ $gameWidth = 1920
 $gameHeight = 1080
 $lightSource = 2.0
 $scaleShader = 1.0
-$aspectRatio = (16.0/9.0)
+$aspectRatioWorld = (16.0/9.0)
+$aspectRatioUI = (16.0/9.0)
 
 ## Colour depth increase - Didn't see any visual improvement.
 #


### PR DESCRIPTION
Add support for 16:10 1280x800 Steam Deck's resolution. I changed the patches to the keep the 16:9 aspect ratio in the hud and menus to avoid cropping, that's why aspect ratio variables are splitted in two.

Here's a picture of it running on my deck:
![IMG_8104](https://github.com/user-attachments/assets/3484dbab-c8db-48a7-b886-0c7ca2d3d24d)

Edit 24th April, 2025:
3D World is corrected in 16:10 aspect ratio. HUD, and UI are a bit stretched because they are rendered in 16:9. If they were rendered in 16:10 they will be cropped due to engine limitations. Anyway, 16:9 HUD and UI distortion is minimal in 16:10 and is not annoying at all if tested on the Steam Deck's display :)

Also in the Steam Deck, remember to set using "Game mode" in Cemu "Stretch to window" aspect ratio and "bilinear" since the emulator believes it's being rendered in 16:9.

Happy to receive your feedback 👍 