### PR TITLE
[BOTW] Added a warning about using draw distance with mods

### DIFF
--- a/src/BreathOfTheWild/Mods/DrawDistance/rules.txt
+++ b/src/BreathOfTheWild/Mods/DrawDistance/rules.txt
@@ -1,6 +1,6 @@
 [Definition]
 titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
-name = Draw Distance
+name = Draw Distance [DON'T USE WITH MODS]
 path = "The Legend of Zelda: Breath of the Wild/Mods/Draw Distance"
 description = Extend the draw distance of objects and entities in the game, which will see a small performance decrease when making it higher.|Lowering this will not offer more performance.|You can also make distant textures appear as higher resolution variants.||Made By Crementif.
 version = 6


### PR DESCRIPTION
I'm a botw modder and helper in the servers, and basically we have an issue with the "Draw Distance" graphic packs, which makes actors load from a bigger distance 

In vanilla with extended memory it's not really a big deal, but as you're probably aware of botw is very limited in memory with mods even with extended memory, and because of that draw distance causes crashes / random bugs with a lot of mods

I did point out in my guides that draw distance should be left off, but since when do people listen or look at our official guides rather than a random youtube tutorial from 2021?

Hence I added a "don't use with mods" warning to the draw distance graphic pack.