### PR TITLE
BotW: fix shadow seam on Steam Deck and other non-16:9 displays

### DIFF
--- a/src/BreathOfTheWild/Graphics/rules.txt
+++ b/src/BreathOfTheWild/Graphics/rules.txt
@@ -666,7 +666,7 @@ height = 368
 formats = 0x001,0x005,0x007,0x019,0x01a,0x80e,0x806,0x816,0x820,0x41a
 # formatsExcluded = 0x431 # Exclude 0x431 which is used for adventure log images
 overwriteWidth = ($width/$gameWidth) * 640
-overwriteHeight = (($height/$gameHeight) * 368) + 0.49
+overwriteHeight = ($height/$gameHeight) * 368
 
 # Required 1/2 resolutions
 [TextureRedefine]
@@ -998,7 +998,7 @@ height = 368
 formats = 0x019
 overwriteFormat = 0x01f
 overwriteWidth = ($width/$gameWidth) * 640
-overwriteHeight = (($height/$gameHeight) * 368) + 0.49
+overwriteHeight = ($height/$gameHeight) * 368
 
 [TextureRedefine]
 width = 640


### PR DESCRIPTION
## What this fixes

A dark horizontal shadow band cuts across the screen in Breath of the Wild when playing at any non-16:9 resolution. This is most visible on **Steam Deck** (1280x800, 16:10) but affects all non-standard aspect ratios — 16:10, 3:2, 4:3, and ultrawide.

The bug has likely been present for every non-16:9 user since the rounding hack was introduced. Anyone who saw a mysterious dark line across the ground in BotW at a custom resolution was hitting this.

## The fix

Remove `+ 0.49` from two height formulas for the `640x368` half-resolution texture. That's it — two characters deleted on two lines.

**Before:** `overwriteHeight = (($height/$gameHeight) * 368) + 0.49`
**After:** `overwriteHeight = ($height/$gameHeight) * 368`

## Why it works

The `+ 0.49` was added as a rounding trick (truncation + 0.49 ≈ round-to-nearest). But for resolutions where the fractional part exceeds 0.51, it rounds **up** by one pixel. That single extra pixel misaligns the shadow cascade boundary, producing the visible seam.

Example at 1280x800 (Steam Deck native):
- With `+ 0.49`: `(10/9) × 368 + 0.49 = 409.38` → truncates to **409** ❌ (1px too tall)
- Without: `(10/9) × 368 = 408.89` → truncates to **408** ✓

At 16:9 resolutions the scaling factor is always an integer, so the result is exact with or without rounding. This fix changes nothing for 16:9 users.

## Tested at
- 1280x800 (Steam Deck native) — shadow seam gone ✓
- 1920x1200 (16:10) — no regression ✓
- 16:9 resolutions — unaffected (integer scaling) ✓