### PR TITLE
[BotW] Add Graphics (16:10 Effect Fix) workaround for non-16:9 rain and shadow artifacts

### DIFF
--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/01ba1a725afa0b96_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/01ba1a725afa0b96_0000000000000000_vs.txt
@@ -1,0 +1,138 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#else
+#define SET_POSITION(_v) gl_Position = _v
+#endif
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+
+const float resScale = $height/720.0;
+
+// Night star (size)
+
+// shader 01ba1a725afa0b96
+UNIFORM_BUFFER_LAYOUT(1, 0, 0) uniform uniformBlockVS1
+{
+vec4 uf_blockVS1[1024];
+};
+
+
+UNIFORM_BUFFER_LAYOUT(2, 0, 1) uniform uniformBlockVS2
+{
+vec4 uf_blockVS2[1024];
+};
+
+
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 0) out vec4 passParameterSem1;
+layout(location = 1) out vec4 passParameterSem2;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+ivec4 R0i = ivec4(0);
+ivec4 R1i = ivec4(0);
+ivec4 R2i = ivec4(0);
+ivec4 R3i = ivec4(0);
+uvec4 attrDecoder;
+int backupReg0i, backupReg1i, backupReg2i, backupReg3i, backupReg4i;
+ivec4 PV0i = ivec4(0), PV1i = ivec4(0);
+int PS0i = 0, PS1i = 0;
+ivec4 tempi = ivec4(0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0i = ivec4(gl_VertexID, 0, 0, gl_InstanceID);
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R1i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), floatBitsToInt(1.0));
+// 0
+R1i.x = floatBitsToInt(uf_blockVS2[7].z);
+R0i.z = R0i.x << int(1);
+PV0i.z = R0i.z;
+R0i.w = 0x3f800000;
+// 1
+R0i.y = PV0i.z + int(1);
+R3i.xyzw = floatBitsToInt(uf_blockVS1[R0i.z].xyzw);
+R2i.xyzw = floatBitsToInt(uf_blockVS1[R0i.y].xyzw);
+// export
+gl_PointSize = intBitsToFloat(R1i.x) * resScale;
+// 0
+backupReg0i = R0i.w;
+backupReg1i = R2i.w;
+R1i.x = floatBitsToInt(dot(vec4(intBitsToFloat(R3i.x),intBitsToFloat(R3i.y),intBitsToFloat(R3i.z),intBitsToFloat(backupReg0i)),vec4(uf_blockVS2[0].x,uf_blockVS2[0].y,uf_blockVS2[0].z,uf_blockVS2[0].w)));
+PV0i.x = R1i.x;
+PV0i.y = R1i.x;
+PV0i.z = R1i.x;
+PV0i.w = R1i.x;
+R2i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(backupReg1i)));
+PS0i = R2i.w;
+// 1
+backupReg0i = R0i.w;
+backupReg1i = R0i.x;
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R3i.x),intBitsToFloat(R3i.y),intBitsToFloat(R3i.z),intBitsToFloat(backupReg0i)),vec4(uf_blockVS2[1].x,uf_blockVS2[1].y,uf_blockVS2[1].z,uf_blockVS2[1].w)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R1i.y = tempi.x;
+R3i.w = floatBitsToInt(float(backupReg1i));
+PS1i = R3i.w;
+// 2
+backupReg0i = R0i.w;
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R3i.x),intBitsToFloat(R3i.y),intBitsToFloat(R3i.z),intBitsToFloat(backupReg0i)),vec4(uf_blockVS2[2].x,uf_blockVS2[2].y,uf_blockVS2[2].z,uf_blockVS2[2].w)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+R1i.z = tempi.x;
+// 3
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R3i.x),intBitsToFloat(R3i.y),intBitsToFloat(R3i.z),intBitsToFloat(R0i.w)),vec4(uf_blockVS2[3].x,uf_blockVS2[3].y,uf_blockVS2[3].z,uf_blockVS2[3].w)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R1i.w = tempi.x;
+// export
+SET_POSITION(vec4(intBitsToFloat(R1i.x), intBitsToFloat(R1i.y), intBitsToFloat(R1i.z), intBitsToFloat(R1i.w)));
+// export
+passParameterSem1 = vec4(intBitsToFloat(R2i.x), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w));
+// export
+passParameterSem2 = vec4(intBitsToFloat(R3i.x), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.w));
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/01bef64ec0cccd53_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/01bef64ec0cccd53_0000000000000000_vs.txt
@@ -1,0 +1,124 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader 01bef64ec0cccd53
+// Used for: Fixing clouds in non-updated versions
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 1) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+TEXTURE_LAYOUT(32, 0, 0) uniform sampler2D textureUnitVS0;
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 1) out vec4 passParameterSem1;
+layout(location = 0) out vec4 passParameterSem0;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+ivec4 R0i = ivec4(0);
+ivec4 R1i = ivec4(0);
+ivec4 R2i = ivec4(0);
+ivec4 R3i = ivec4(0);
+ivec4 R127i = ivec4(0);
+uvec4 attrDecoder;
+int backupReg0i, backupReg1i, backupReg2i, backupReg3i, backupReg4i;
+ivec4 PV0i = ivec4(0), PV1i = ivec4(0);
+int PS0i = 0, PS1i = 0;
+ivec4 tempi = ivec4(0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0i = ivec4(gl_VertexID, 0, 0, gl_InstanceID);
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R1i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), floatBitsToInt(1.0));
+attrDecoder.xy = attrDataSem1.xy;
+attrDecoder.xy = (attrDecoder.xy>>24)|((attrDecoder.xy>>8)&0xFF00)|((attrDecoder.xy<<8)&0xFF0000)|((attrDecoder.xy<<24));
+attrDecoder.z = 0;
+attrDecoder.w = 0;
+R2i = ivec4(int(attrDecoder.x), int(attrDecoder.y), floatBitsToInt(0.0), floatBitsToInt(1.0));
+// 0
+backupReg0i = R1i.x;
+backupReg1i = R1i.y;
+R1i.x = backupReg0i;
+R1i.x = floatBitsToInt(intBitsToFloat(R1i.x) * 2.0);
+R1i.y = backupReg1i;
+R1i.y = floatBitsToInt(intBitsToFloat(R1i.y) * 2.0);
+R1i.z = 0x3f800000;
+R0i.w = 0;
+R0i.y = floatBitsToInt(-(intBitsToFloat(uf_remappedVS[0].z)/resXScale));
+R0i.y = floatBitsToInt(intBitsToFloat(R0i.y) / 2.0);
+PS0i = R0i.y;
+R3i.xy = ivec4(textureSize(textureUnitVS0, 0),1,1).xy;
+// export
+SET_POSITION(vec4(intBitsToFloat(R1i.x), intBitsToFloat(R1i.y), intBitsToFloat(R1i.z), intBitsToFloat(R1i.z)));
+// 0
+PV0i.x = floatBitsToInt(-(intBitsToFloat(uf_remappedVS[0].w)/resYScale));
+PV0i.x = floatBitsToInt(intBitsToFloat(PV0i.x) / 2.0);
+R0i.z = R0i.y;
+R127i.w = floatBitsToInt(float(R3i.x));
+PS0i = R127i.w;
+// 1
+R0i.w = PV0i.x;
+R127i.z = floatBitsToInt(float(R3i.y));
+PS1i = R127i.z;
+// 2
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(R127i.w));
+// 3
+R3i.x = floatBitsToInt((-(intBitsToFloat(PS0i)) * intBitsToFloat(0x3c23d70a) + intBitsToFloat(R2i.x)));
+PV1i.x = R3i.x;
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(R127i.z));
+// 4
+R0i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.x),intBitsToFloat(uf_remappedVS[0].x)*resXScale) + 0.5));
+R3i.y = floatBitsToInt((-(intBitsToFloat(PS1i)) * intBitsToFloat(0x3c23d70a) + intBitsToFloat(R2i.y)));
+PV0i.y = R3i.y;
+// 5
+R0i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.y),intBitsToFloat(uf_remappedVS[0].y)*resYScale) + 0.5));
+// export
+passParameterSem1 = vec4(intBitsToFloat(R0i.x), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
+// export
+passParameterSem0 = vec4(intBitsToFloat(R3i.x), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.z));
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/0b9b8f5dfa16ad58_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/0b9b8f5dfa16ad58_0000000000000000_vs.txt
@@ -1,0 +1,135 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader 0b9b8f5dfa16ad58
+// Used For: Horizontal Menu Blur
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 0) out vec4 passParameterSem0;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R126f = vec4(0.0);
+vec4 R127f = vec4(0.0);
+uvec4 attrDecoder;
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = floatBitsToInt(ivec4(gl_VertexID, 0, 0, gl_InstanceID));
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R1f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(floatBitsToInt(1.0)));
+// 0
+R127f.x = (R1f.x > 0.0)?1.0:0.0;
+R127f.x /= 2.0;
+R127f.y = -(R1f.y);
+PV0f.y = R127f.y;
+R127f.z = (0.0 > R1f.x)?1.0:0.0;
+R127f.z /= 2.0;
+R127f.w = 1.0;
+PV0f.w = R127f.w;
+R126f.x = intBitsToFloat(uf_remappedVS[0].z) * (intBitsToFloat(0x3fae8a72)/resXScale);
+PS0f = R126f.x;
+// 1
+R0f.x = dot(vec4(R1f.x,R1f.y,R1f.z,PV0f.w),vec4(intBitsToFloat(uf_remappedVS[1].x),intBitsToFloat(uf_remappedVS[1].y),intBitsToFloat(uf_remappedVS[1].z),intBitsToFloat(uf_remappedVS[1].w)));
+PV1f.x = R0f.x;
+PV1f.y = R0f.x;
+PV1f.z = R0f.x;
+PV1f.w = R0f.x;
+R126f.w = (PV0f.y > 0.0)?1.0:0.0;
+R126f.w /= 2.0;
+PS1f = R126f.w;
+// 2
+backupReg0f = R127f.y;
+tempf.x = dot(vec4(R1f.x,R1f.y,R1f.z,R127f.w),vec4(intBitsToFloat(uf_remappedVS[2].x),intBitsToFloat(uf_remappedVS[2].y),intBitsToFloat(uf_remappedVS[2].z),intBitsToFloat(uf_remappedVS[2].w)));
+PV0f.x = tempf.x;
+PV0f.y = tempf.x;
+PV0f.z = tempf.x;
+PV0f.w = tempf.x;
+R0f.y = tempf.x;
+R127f.y = (0.0 > backupReg0f)?1.0:0.0;
+R127f.y /= 2.0;
+PS0f = R127f.y;
+// 3
+backupReg0f = R127f.x;
+tempf.x = dot(vec4(R1f.x,R1f.y,R1f.z,R127f.w),vec4(intBitsToFloat(uf_remappedVS[3].x),intBitsToFloat(uf_remappedVS[3].y),intBitsToFloat(uf_remappedVS[3].z),intBitsToFloat(uf_remappedVS[3].w)));
+PV1f.x = tempf.x;
+PV1f.y = tempf.x;
+PV1f.z = tempf.x;
+PV1f.w = tempf.x;
+R0f.z = tempf.x;
+R127f.x = backupReg0f + -(R127f.z);
+PS1f = R127f.x;
+// 4
+tempf.x = dot(vec4(R1f.x,R1f.y,R1f.z,R127f.w),vec4(intBitsToFloat(uf_remappedVS[4].x),intBitsToFloat(uf_remappedVS[4].y),intBitsToFloat(uf_remappedVS[4].z),intBitsToFloat(uf_remappedVS[4].w)));
+PV0f.x = tempf.x;
+PV0f.y = tempf.x;
+PV0f.z = tempf.x;
+PV0f.w = tempf.x;
+R0f.w = tempf.x;
+PS0f = R126f.w + -(R127f.y);
+// 5
+PV1f.y = PS0f + 0.5;
+PV1f.z = R127f.x + 0.5;
+// 6
+R1f.x = PV1f.y;
+R1f.y = PV1f.z + -(R126f.x);
+R1f.z = PV1f.z + R126f.x;
+R1f.w = PV1f.z;
+// export
+SET_POSITION(vec4(R0f.x, R0f.y, R0f.z, R0f.w));
+// export
+passParameterSem0 = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/0bcd653c18367d59_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/0bcd653c18367d59_0000000000000000_vs.txt
@@ -1,0 +1,239 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader 0bcd653c18367d59
+// Used for: Restoring the native BotW Anti-Aliasing implementation
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 1) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+TEXTURE_LAYOUT(32, 0, 0) uniform sampler2D textureUnitVS0;
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 3) out vec4 passParameterSem4;
+layout(location = 0) out vec4 passParameterSem0;
+layout(location = 1) out vec4 passParameterSem1;
+layout(location = 2) out vec4 passParameterSem3;
+layout(location = 4) out vec4 passParameterSem6;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+ivec4 R0i = ivec4(0);
+ivec4 R1i = ivec4(0);
+ivec4 R2i = ivec4(0);
+ivec4 R3i = ivec4(0);
+ivec4 R4i = ivec4(0);
+ivec4 R5i = ivec4(0);
+ivec4 R6i = ivec4(0);
+ivec4 R7i = ivec4(0);
+ivec4 R123i = ivec4(0);
+ivec4 R124i = ivec4(0);
+ivec4 R125i = ivec4(0);
+ivec4 R126i = ivec4(0);
+ivec4 R127i = ivec4(0);
+uvec4 attrDecoder;
+int backupReg0i, backupReg1i, backupReg2i, backupReg3i, backupReg4i;
+ivec4 PV0i = ivec4(0), PV1i = ivec4(0);
+int PS0i = 0, PS1i = 0;
+ivec4 tempi = ivec4(0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0i = ivec4(gl_VertexID, 0, 0, gl_InstanceID);
+attrDecoder.xyzw = attrDataSem0.xyzw;
+attrDecoder = ((attrDecoder>>8)&0xFF)|((attrDecoder<<8)&0xFF00);
+attrDecoder.xyzw = floatBitsToInt(vec4(unpackHalf2x16(attrDecoder.x|(attrDecoder.y<<16)),unpackHalf2x16(attrDecoder.z|(attrDecoder.w<<16))));
+R1i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder.x = attrDataSem1.x;
+attrDecoder.x = (attrDecoder.x>>24)|((attrDecoder.x>>8)&0xFF00)|((attrDecoder.x<<8)&0xFF0000)|((attrDecoder.x<<24));
+attrDecoder.y = 0;
+attrDecoder.z = 0;
+attrDecoder.w = 0;
+attrDecoder.xyzw = uvec4((attrDecoder.x>>0)&0x3FF,(attrDecoder.x>>10)&0x3FF,(attrDecoder.x>>20)&0x3FF,(attrDecoder.x>>30)&0x3);
+if( (attrDecoder.x&0x200) != 0 ) attrDecoder.x |= 0xFFFFFC00;
+if( (attrDecoder.y&0x200) != 0 ) attrDecoder.y |= 0xFFFFFC00;
+if( (attrDecoder.z&0x200) != 0 ) attrDecoder.z |= 0xFFFFFC00;
+attrDecoder.x = floatBitsToUint(max(float(int(attrDecoder.x))/511.0,-1.0));
+attrDecoder.y = floatBitsToUint(max(float(int(attrDecoder.y))/511.0,-1.0));
+attrDecoder.z = floatBitsToUint(max(float(int(attrDecoder.z))/511.0,-1.0));
+attrDecoder.w = floatBitsToUint(float(attrDecoder.w));
+R2i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+// 0
+backupReg0i = R0i.x;
+PV0i.x = (backupReg0i == int(1))?int(0xFFFFFFFF):int(0x0);
+R127i.y = 0x3f800000;
+PV0i.z = 0x3f800000;
+PV0i.w = 0x40400000;
+R127i.z = 0xbf800000;
+PS0i = R127i.z;
+// 1
+R123i.x = ((PV0i.x == 0)?(PV0i.z):(0xc0400000));
+PV1i.x = R123i.x;
+R123i.y = ((PV0i.x == 0)?(PV0i.w):(0xbf800000));
+PV1i.y = R123i.y;
+R0i.z = 0;
+PV1i.w = floatBitsToInt(intBitsToFloat(uf_remappedVS[0].z) * intBitsToFloat(0x3b808081));
+R2i.w = 0x3f800000;
+PS1i = R2i.w;
+// 2
+R2i.x = ((R0i.x == 0)?(R127i.z):(PV1i.y));
+PV0i.x = R2i.x;
+R2i.y = ((R0i.x == 0)?(R127i.y):(PV1i.x));
+PV0i.y = R2i.y;
+R2i.z = floatBitsToInt(intBitsToFloat(PV1i.w) + -(0.5));
+R2i.z = floatBitsToInt(intBitsToFloat(R2i.z) * 2.0);
+R0i.w = 0x3d2aaaab;
+R0i.x = 0x3e000000;
+PS0i = R0i.x;
+// 3
+R5i.x = floatBitsToInt((intBitsToFloat(PV0i.x) * 0.5 + 0.5));
+PV1i.x = R5i.x;
+R0i.y = 0;
+PV1i.z = floatBitsToInt(-(intBitsToFloat(PV0i.y)));
+R4i.w = uf_remappedVS[1].z;
+R4i.w = floatBitsToInt(intBitsToFloat(R4i.w) / 2.0);
+R3i.x = floatBitsToInt(-(intBitsToFloat(uf_remappedVS[2].z)));
+R3i.x = floatBitsToInt(intBitsToFloat(R3i.x) / 2.0);
+PS1i = R3i.x;
+// 4
+R6i.x = floatBitsToInt(-(intBitsToFloat(uf_remappedVS[3].x)));
+R6i.x = floatBitsToInt(intBitsToFloat(R6i.x) * 2.0);
+R5i.y = floatBitsToInt((intBitsToFloat(PV1i.z) * 0.5 + 0.5));
+R7i.z = PV1i.x;
+R3i.w = R2i.x;
+R3i.w = floatBitsToInt(intBitsToFloat(R3i.w) / 2.0);
+R6i.y = uf_remappedVS[3].y;
+R6i.y = floatBitsToInt(intBitsToFloat(R6i.y) * 2.0);
+PS0i = R6i.y;
+R1i.w = floatBitsToInt(texture(textureUnitVS0, intBitsToFloat(R0i.wz)).x);
+R1i.xyz = floatBitsToInt(texture(textureUnitVS0, intBitsToFloat(R0i.xy)).xyz);
+// export
+SET_POSITION(vec4(intBitsToFloat(R2i.x), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w)));
+// export
+// skipped export to semanticId 255
+// 0
+R126i.x = floatBitsToInt(intBitsToFloat(R3i.x) + -(0.5));
+R125i.y = floatBitsToInt(intBitsToFloat(R4i.w) + -(0.5));
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R2i.y)));
+PV0i.z = floatBitsToInt(intBitsToFloat(PV0i.z) / 2.0);
+R7i.w = R5i.y;
+PV0i.w = R7i.w;
+R127i.y = floatBitsToInt(-(intBitsToFloat(R6i.x)));
+R127i.y = floatBitsToInt(intBitsToFloat(R127i.y) / 2.0);
+PS0i = R127i.y;
+// 1
+R127i.x = floatBitsToInt(-(intBitsToFloat(R6i.y)));
+R127i.x = floatBitsToInt(intBitsToFloat(R127i.x) / 2.0);
+R126i.y = floatBitsToInt(intBitsToFloat(R3i.w) + intBitsToFloat(R4i.w));
+PV1i.z = floatBitsToInt(intBitsToFloat(PV0i.w) + intBitsToFloat(uf_remappedVS[4].w)/resYScale);
+PV1i.w = floatBitsToInt(intBitsToFloat(PV0i.z) + intBitsToFloat(R3i.x));
+R127i.w = floatBitsToInt(intBitsToFloat(R7i.z) + intBitsToFloat(uf_remappedVS[4].z)/resXScale);
+PS1i = R127i.w;
+// 2
+backupReg0i = R127i.y;
+R125i.x = floatBitsToInt(intBitsToFloat(PV1i.z) + intBitsToFloat(R126i.x));
+R127i.y = floatBitsToInt(intBitsToFloat(R5i.x) + intBitsToFloat(R125i.y));
+R126i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R6i.y), intBitsToFloat(PV1i.w)));
+R126i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.x),intBitsToFloat(R4i.w)) + intBitsToFloat(backupReg0i)));
+R125i.w = floatBitsToInt(intBitsToFloat(uf_remappedVS[4].z)/resXScale);
+PS0i = R125i.w;
+// 3
+backupReg0i = R126i.y;
+backupReg1i = R127i.x;
+R127i.x = floatBitsToInt(-(intBitsToFloat(uf_remappedVS[4].w)/resYScale));
+R126i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R6i.x), intBitsToFloat(backupReg0i)));
+R127i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.y),intBitsToFloat(R3i.x)) + intBitsToFloat(backupReg1i)));
+R124i.w = floatBitsToInt(intBitsToFloat(uf_remappedVS[4].x)*resXScale);
+R124i.w = floatBitsToInt(intBitsToFloat(R124i.w) / 2.0);
+R125i.z = floatBitsToInt(intBitsToFloat(uf_remappedVS[4].y)*resYScale);
+R125i.z = floatBitsToInt(intBitsToFloat(R125i.z) / 2.0);
+PS1i = R125i.z;
+// 4
+backupReg0i = R126i.x;
+backupReg1i = R127i.w;
+backupReg2i = R127i.y;
+R126i.x = floatBitsToInt(intBitsToFloat(uf_remappedVS[4].w)/resYScale);
+R126i.x = floatBitsToInt(intBitsToFloat(R126i.x) * 2.0);
+R127i.y = floatBitsToInt(intBitsToFloat(uf_remappedVS[4].z)/resXScale);
+R127i.y = floatBitsToInt(intBitsToFloat(R127i.y) * 2.0);
+R124i.z = floatBitsToInt(intBitsToFloat(R5i.y) + intBitsToFloat(backupReg0i));
+R127i.w = floatBitsToInt(intBitsToFloat(backupReg1i) + intBitsToFloat(R125i.y));
+R4i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R6i.x), intBitsToFloat(backupReg2i)));
+PS0i = R4i.w;
+// 5
+backupReg0i = R127i.z;
+R2i.x = floatBitsToInt(intBitsToFloat(R125i.w) * 1.5);
+R2i.y = floatBitsToInt(intBitsToFloat(R127i.x) * 1.5);
+R127i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R6i.y), intBitsToFloat(R125i.x)));
+R6i.w = backupReg0i;
+R6i.z = R126i.w;
+PS1i = R6i.z;
+// 6
+R3i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.x),intBitsToFloat(R124i.w)) + 0.5));
+R3i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.y),intBitsToFloat(R125i.z)) + 0.5));
+R5i.z = R126i.y;
+R5i.w = R126i.z;
+R3i.z = R127i.y;
+PS0i = R3i.z;
+// 7
+R4i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R6i.x), intBitsToFloat(R127i.w)));
+R4i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R6i.y), intBitsToFloat(R124i.z)));
+R4i.z = R4i.w;
+R3i.w = R126i.x;
+R4i.w = R127i.z;
+PS1i = R4i.w;
+// export
+passParameterSem4 = vec4(intBitsToFloat(R3i.x), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.w));
+// export
+// skipped export to semanticId 255
+// export
+passParameterSem0 = vec4(intBitsToFloat(R5i.x), intBitsToFloat(R5i.y), intBitsToFloat(R5i.z), intBitsToFloat(R5i.w));
+// export
+passParameterSem1 = vec4(intBitsToFloat(R6i.x), intBitsToFloat(R6i.y), intBitsToFloat(R6i.z), intBitsToFloat(R6i.w));
+// export
+passParameterSem3 = vec4(intBitsToFloat(R2i.x), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.z));
+// export
+passParameterSem6 = vec4(intBitsToFloat(R7i.x), intBitsToFloat(R7i.x), intBitsToFloat(R7i.z), intBitsToFloat(R7i.w));
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/0d6127fbed646d2b_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/0d6127fbed646d2b_0000000000000000_vs.txt
@@ -1,0 +1,203 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader 0d6127fbed646d2b
+// Used for: Fixing Ambient-Occlusion
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 1) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+TEXTURE_LAYOUT(32, 0, 0) uniform sampler2D textureUnitVS0;
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 0) out vec4 passParameterSem0;
+layout(location = 1) out vec4 passParameterSem5;
+layout(location = 2) out vec4 passParameterSem6;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+ivec4 R0i = ivec4(0);
+ivec4 R1i = ivec4(0);
+ivec4 R2i = ivec4(0);
+ivec4 R3i = ivec4(0);
+ivec4 R4i = ivec4(0);
+ivec4 R123i = ivec4(0);
+ivec4 R124i = ivec4(0);
+ivec4 R125i = ivec4(0);
+ivec4 R126i = ivec4(0);
+ivec4 R127i = ivec4(0);
+uvec4 attrDecoder;
+int backupReg0i, backupReg1i, backupReg2i, backupReg3i, backupReg4i;
+ivec4 PV0i = ivec4(0), PV1i = ivec4(0);
+int PS0i = 0, PS1i = 0;
+ivec4 tempi = ivec4(0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0i = ivec4(gl_VertexID, 0, 0, gl_InstanceID);
+attrDecoder.xyzw = attrDataSem0.xyzw;
+attrDecoder = ((attrDecoder>>8)&0xFF)|((attrDecoder<<8)&0xFF00);
+attrDecoder.xyzw = floatBitsToInt(vec4(unpackHalf2x16(attrDecoder.x|(attrDecoder.y<<16)),unpackHalf2x16(attrDecoder.z|(attrDecoder.w<<16))));
+R1i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder.x = attrDataSem1.x;
+attrDecoder.x = (attrDecoder.x>>24)|((attrDecoder.x>>8)&0xFF00)|((attrDecoder.x<<8)&0xFF0000)|((attrDecoder.x<<24));
+attrDecoder.y = 0;
+attrDecoder.z = 0;
+attrDecoder.w = 0;
+attrDecoder.xyzw = uvec4((attrDecoder.x>>0)&0x3FF,(attrDecoder.x>>10)&0x3FF,(attrDecoder.x>>20)&0x3FF,(attrDecoder.x>>30)&0x3);
+if( (attrDecoder.x&0x200) != 0 ) attrDecoder.x |= 0xFFFFFC00;
+if( (attrDecoder.y&0x200) != 0 ) attrDecoder.y |= 0xFFFFFC00;
+if( (attrDecoder.z&0x200) != 0 ) attrDecoder.z |= 0xFFFFFC00;
+attrDecoder.x = floatBitsToUint(max(float(int(attrDecoder.x))/511.0,-1.0));
+attrDecoder.y = floatBitsToUint(max(float(int(attrDecoder.y))/511.0,-1.0));
+attrDecoder.z = floatBitsToUint(max(float(int(attrDecoder.z))/511.0,-1.0));
+attrDecoder.w = floatBitsToUint(float(attrDecoder.w));
+R2i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+// 0
+backupReg0i = R0i.x;
+PV0i.x = 0x3f800000;
+PV0i.y = 0x40400000;
+PV0i.z = (backupReg0i == int(1))?int(0xFFFFFFFF):int(0x0);
+R127i.w = 0x3f800000;
+R127i.x = 0xbf800000;
+PS0i = R127i.x;
+// 1
+R3i.x = uf_remappedVS[0].z;
+R3i.x = floatBitsToInt(intBitsToFloat(R3i.x) / 2.0);
+PV1i.y = floatBitsToInt(intBitsToFloat(uf_remappedVS[1].z) * intBitsToFloat(0x3b808081));
+R123i.z = ((PV0i.z == 0)?(PV0i.x):(0xc0400000));
+PV1i.z = R123i.z;
+R123i.w = ((PV0i.z == 0)?(PV0i.y):(0xbf800000));
+PV1i.w = R123i.w;
+R2i.w = 0x3f800000;
+PS1i = R2i.w;
+// 2
+R2i.x = ((R0i.x == 0)?(R127i.x):(PV1i.w));
+PV0i.x = R2i.x;
+R2i.y = ((R0i.x == 0)?(R127i.w):(PV1i.z));
+PV0i.y = R2i.y;
+R2i.z = floatBitsToInt(intBitsToFloat(PV1i.y) + -(0.5));
+R2i.z = floatBitsToInt(intBitsToFloat(R2i.z) * 2.0);
+R0i.w = 0x3d2aaaab;
+R0i.y = 0;
+PS0i = R0i.y;
+// 3
+R1i.xyz = ivec3(0x3e000000,0,floatBitsToInt(-(intBitsToFloat(PV0i.y))));
+R1i.w = floatBitsToInt(-(intBitsToFloat(uf_remappedVS[2].z)));
+R1i.w = floatBitsToInt(intBitsToFloat(R1i.w) / 2.0);
+R4i.x = floatBitsToInt((intBitsToFloat(PV0i.x) * 0.5 + 0.5));
+PS1i = R4i.x;
+R0i.w = floatBitsToInt(texture(textureUnitVS0, intBitsToFloat(R0i.wy)).x);
+R0i.xyz = floatBitsToInt(texture(textureUnitVS0, intBitsToFloat(R1i.xy)).xyz);
+// export
+SET_POSITION(vec4(intBitsToFloat(R2i.x), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w)));
+// export
+// skipped export to semanticId 255
+// 0
+R126i.x = floatBitsToInt(intBitsToFloat(R3i.x) + -(0.5));
+R4i.y = floatBitsToInt((intBitsToFloat(R1i.z) * 0.5 + 0.5));
+PV0i.y = R4i.y;
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R2i.y)));
+PV0i.z = floatBitsToInt(intBitsToFloat(PV0i.z) / 2.0);
+PV0i.w = R2i.x;
+PV0i.w = floatBitsToInt(intBitsToFloat(PV0i.w) / 2.0);
+R125i.z = floatBitsToInt(intBitsToFloat(R1i.w) + -(0.5));
+PS0i = R125i.z;
+// 1
+R123i.x = floatBitsToInt((intBitsToFloat(uf_remappedVS[3].w) * 2.0 / resYScale + intBitsToFloat(PV0i.y)));
+PV1i.x = R123i.x;
+R126i.y = floatBitsToInt(-(intBitsToFloat(uf_remappedVS[4].x)));
+R126i.y = floatBitsToInt(intBitsToFloat(R126i.y) * 2.0);
+R1i.z = uf_remappedVS[4].y;
+R1i.z = floatBitsToInt(intBitsToFloat(R1i.z) * 2.0);
+R127i.w = floatBitsToInt(intBitsToFloat(PV0i.w) + intBitsToFloat(R3i.x));
+R127i.z = floatBitsToInt(intBitsToFloat(PV0i.z) + intBitsToFloat(R1i.w));
+PS1i = R127i.z;
+// 2
+R127i.x = floatBitsToInt(intBitsToFloat(uf_remappedVS[3].y) * resYScale);
+R127i.x = floatBitsToInt(intBitsToFloat(R127i.x) / 2.0);
+PV0i.y = floatBitsToInt(intBitsToFloat(uf_remappedVS[3].x) * resXScale);
+PV0i.y = floatBitsToInt(intBitsToFloat(PV0i.y) / 2.0);
+R126i.z = floatBitsToInt((intBitsToFloat(uf_remappedVS[3].z) * 2.0 / resXScale + intBitsToFloat(R4i.x)));
+R126i.w = floatBitsToInt(intBitsToFloat(R4i.x) + intBitsToFloat(R126i.x));
+R124i.z = floatBitsToInt(intBitsToFloat(PV1i.x) + intBitsToFloat(R125i.z));
+PS0i = R124i.z;
+// 3
+R125i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.z), intBitsToFloat(R127i.z)));
+R127i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.y), intBitsToFloat(R127i.w)));
+R127i.z = floatBitsToInt((-(intBitsToFloat(uf_remappedVS[3].w)/resYScale) * intBitsToFloat(0x3c23d70a) + intBitsToFloat(R4i.y)));
+R123i.w = floatBitsToInt((-(intBitsToFloat(uf_remappedVS[3].z)/resXScale) * intBitsToFloat(0x3c23d70a) + intBitsToFloat(R4i.x)));
+PV1i.w = R123i.w;
+R127i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R4i.x), intBitsToFloat(PV0i.y)));
+PS1i = R127i.w;
+// 4
+backupReg0i = R126i.w;
+PV0i.x = floatBitsToInt(intBitsToFloat(R4i.y) + intBitsToFloat(R125i.z));
+PV0i.y = floatBitsToInt(intBitsToFloat(R126i.z) + intBitsToFloat(R126i.x));
+R126i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R4i.y), intBitsToFloat(R127i.x)));
+R126i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.y), intBitsToFloat(backupReg0i)));
+R3i.z = PV1i.w;
+PS0i = R3i.z;
+// 5
+R1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.y), intBitsToFloat(PV0i.y)));
+R1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.z), intBitsToFloat(PV0i.x)));
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.z), intBitsToFloat(R124i.z)));
+R3i.w = R127i.z;
+R4i.z = R127i.y;
+PS1i = R4i.z;
+// 6
+R3i.x = floatBitsToInt(intBitsToFloat(R127i.w) * 0.25);
+R3i.y = floatBitsToInt(intBitsToFloat(R126i.z) * 0.25);
+R1i.z = R126i.w;
+R4i.w = R125i.x;
+R1i.w = PV1i.z;
+PS0i = R1i.w;
+// export
+passParameterSem0 = vec4(intBitsToFloat(R4i.x), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w));
+// export
+passParameterSem5 = vec4(intBitsToFloat(R1i.x), intBitsToFloat(R1i.y), intBitsToFloat(R1i.z), intBitsToFloat(R1i.w));
+// export
+passParameterSem6 = vec4(intBitsToFloat(R3i.x), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.w));
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/0f2b9ee517917425_00000000000003c9_ps.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/0f2b9ee517917425_00000000000003c9_ps.txt
@@ -1,0 +1,1045 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader 0f2b9ee517917425 - dumped cemu 1.15
+// Used for: Restoring the native BotW Anti-Aliasing implementation in inventory screen
+
+const float resX = float($width)/float($gameWidth);
+const float resY = float($height)/float($gameHeight);
+#define fxaa $fxaa
+
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
+uniform ivec4 uf_remappedPS[2];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[2];
+uniform vec2 uf_fragCoordScale;
+#endif
+
+#if (fxaa == 0) // Disabled AA
+
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+layout(location = 0) in vec4 passParameterSem2;
+layout(location = 0) out vec4 passPixelColor0;
+
+void main()
+{
+passPixelColor0 = texture(textureUnitPS0, passParameterSem2.xy);
+}
+
+#elif (fxaa == 1)
+
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
+layout(location = 0) in vec4 passParameterSem2;
+layout(location = 0) out vec4 passPixelColor0;
+// uf_fragCoordScale was moved to the ufBlock
+
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){return mix(0.0, a*b, (a != 0.0) && (b != 0.0));}
+void main()
+{
+ivec4 R0i = ivec4(0);
+ivec4 R1i = ivec4(0);
+ivec4 R2i = ivec4(0);
+ivec4 R3i = ivec4(0);
+ivec4 R4i = ivec4(0);
+ivec4 R5i = ivec4(0);
+ivec4 R6i = ivec4(0);
+ivec4 R123i = ivec4(0);
+ivec4 R124i = ivec4(0);
+ivec4 R125i = ivec4(0);
+ivec4 R126i = ivec4(0);
+ivec4 R127i = ivec4(0);
+int backupReg0i, backupReg1i, backupReg2i, backupReg3i, backupReg4i;
+ivec4 PV0i = ivec4(0), PV1i = ivec4(0); // These variables make the difference
+int PS0i = 0, PS1i = 0;
+ivec4 tempi = ivec4(0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+bool activeMaskStack[2];
+bool activeMaskStackC[3];
+activeMaskStack[0] = false;
+activeMaskStackC[0] = false;
+activeMaskStackC[1] = false;
+activeMaskStack[0] = true;
+activeMaskStackC[0] = true;
+activeMaskStackC[1] = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0i = floatBitsToInt(passParameterSem2);
+if( activeMaskStackC[1] == true ) {
+R2i.xzw = floatBitsToInt(textureGather(textureUnitPS1, intBitsToFloat(R0i.xy)).xzw);
+R1i.xz = floatBitsToInt(textureGather(textureUnitPS1, intBitsToFloat(R0i.zw)).xz);
+R3i.xyzw = floatBitsToInt(texture(textureUnitPS0, intBitsToFloat(R0i.xy)).xyzw);
+R0i.w = floatBitsToInt(textureOffset(textureUnitPS1, intBitsToFloat(R0i.xy),ivec2(1,-1)).x);
+R1i.y = floatBitsToInt(textureOffset(textureUnitPS1, intBitsToFloat(R0i.xy),ivec2(-1,1)).x);
+}
+if( activeMaskStackC[1] == true ) {
+activeMaskStack[1] = activeMaskStack[0];
+activeMaskStackC[2] = activeMaskStackC[1];
+// 0 --- Point of Interest 1
+PV0i.x = floatBitsToInt(min(intBitsToFloat(R1i.x), intBitsToFloat(R1i.z)) / resX ); // Divide looks better for minimum - Must place the varaibles in that location of the round brackets to use floats correctly
+PV0i.y = floatBitsToInt(max(intBitsToFloat(R2i.x), intBitsToFloat(R2i.z)) * resY ); // Multiply looks beeter for max - Must place the varaibles in that location of the round brackets to use floats correctly
+PV0i.z = floatBitsToInt(max(intBitsToFloat(R1i.x), intBitsToFloat(R1i.z)) * resX ); // Multiply looks better for max  - Must place the varaibles in that location of the round brackets to use floats correctly
+PV0i.w = floatBitsToInt(min(intBitsToFloat(R2i.x), intBitsToFloat(R2i.z)));
+// 1 ---Point of Interest 2
+PV1i.x = floatBitsToInt(max(intBitsToFloat(PV0i.z), intBitsToFloat(PV0i.y)));
+PV1i.y = floatBitsToInt(min(intBitsToFloat(PV0i.x), intBitsToFloat(PV0i.w)));
+// 2
+PV0i.z = floatBitsToInt(min(intBitsToFloat(R2i.w), intBitsToFloat(PV1i.y)));
+PV0i.w = floatBitsToInt(max(intBitsToFloat(R2i.w), intBitsToFloat(PV1i.x)));
+// 3 
+PV1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.w), intBitsToFloat(uf_remappedPS[0].x)));
+R1i.w = floatBitsToInt(intBitsToFloat(PV0i.w) + -(intBitsToFloat(PV0i.z)));
+// 4 
+R2i.y = floatBitsToInt(max(intBitsToFloat(PV1i.x), intBitsToFloat(uf_remappedPS[0].y)));
+// 5
+predResult = (intBitsToFloat(R1i.w) >= intBitsToFloat(R2i.y));
+activeMaskStack[1] = predResult;
+activeMaskStackC[2] = predResult == true && activeMaskStackC[1] == true;
+}
+else {
+activeMaskStack[1] = false;
+activeMaskStackC[2] = false;
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+R126i.xyz = floatBitsToInt(vec3(intBitsToFloat(R2i.z),intBitsToFloat(R1i.x),intBitsToFloat(R2i.z)) + vec3(intBitsToFloat(R0i.w),intBitsToFloat(R1i.y),intBitsToFloat(R1i.x)));
+PV0i.z = R126i.z;
+R127i.w = floatBitsToInt(intBitsToFloat(R2i.x) + intBitsToFloat(R1i.z));
+PV0i.w = R127i.w;
+R127i.y = R1i.z;
+R127i.y = floatBitsToInt(intBitsToFloat(R127i.y) * 2.0);
+PS0i = R127i.y;
+// 1
+PV1i.x = R2i.x;
+PV1i.x = floatBitsToInt(intBitsToFloat(PV1i.x) * 2.0);
+PV1i.y = floatBitsToInt(intBitsToFloat(R1i.x) + intBitsToFloat(R0i.w));
+R127i.z = floatBitsToInt((-(intBitsToFloat(R2i.w)) * 2.0 + intBitsToFloat(PV0i.z)));
+PV1i.w = PV0i.w;
+PS1i = floatBitsToInt(intBitsToFloat(R2i.z) + intBitsToFloat(R1i.y));
+// 2
+R127i.x = floatBitsToInt((-(intBitsToFloat(R2i.w)) * 2.0 + intBitsToFloat(PV1i.w)));
+R1i.y = R2i.z;
+PV0i.y = R1i.y;
+PV0i.z = floatBitsToInt(intBitsToFloat(PS1i) + -(intBitsToFloat(PV1i.x)));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV1i.y) + -(intBitsToFloat(R127i.y)));
+PS0i = R126i.x;
+// 3
+backupReg0i = R127i.z;
+backupReg0i = R127i.z;
+R123i.x = floatBitsToInt((-(intBitsToFloat(R1i.x)) * 2.0 + intBitsToFloat(R126i.y)));
+PV1i.x = R123i.x;
+PV1i.y = floatBitsToInt(max(intBitsToFloat(PV0i.w), -(intBitsToFloat(PV0i.w))));
+R127i.z = floatBitsToInt(max(intBitsToFloat(PV0i.z), -(intBitsToFloat(PV0i.z))));
+R123i.w = floatBitsToInt((-(intBitsToFloat(PV0i.y)) * 2.0 + intBitsToFloat(PS0i)));
+PV1i.w = R123i.w;
+PS1i = floatBitsToInt(max(intBitsToFloat(backupReg0i), -(intBitsToFloat(backupReg0i))));
+PS1i = floatBitsToInt(intBitsToFloat(PS1i) * 2.0);
+// 4
+backupReg0i = R126i.y;
+PV0i.x = floatBitsToInt(max(intBitsToFloat(PV1i.x), -(intBitsToFloat(PV1i.x))));
+R126i.y = floatBitsToInt(max(intBitsToFloat(PV1i.w), -(intBitsToFloat(PV1i.w))));
+PV0i.z = floatBitsToInt(max(intBitsToFloat(R127i.x), -(intBitsToFloat(R127i.x))));
+PV0i.z = floatBitsToInt(intBitsToFloat(PV0i.z) * 2.0);
+PV0i.w = floatBitsToInt(intBitsToFloat(PV1i.y) + intBitsToFloat(PS1i));
+R126i.w = floatBitsToInt(intBitsToFloat(R126i.x) + intBitsToFloat(backupReg0i));
+PS0i = R126i.w;
+// 5
+backupReg0i = R127i.z;
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.x) + intBitsToFloat(PV0i.z));
+PV1i.y = floatBitsToInt(intBitsToFloat(R127i.w) + intBitsToFloat(R126i.z));
+PV1i.y = floatBitsToInt(intBitsToFloat(PV1i.y) * 2.0);
+R127i.z = floatBitsToInt(intBitsToFloat(backupReg0i) + intBitsToFloat(PV0i.w));
+R127i.y = floatBitsToInt(1.0 / intBitsToFloat(R1i.w)); // Rli.w * 2  has the same affect as line 85------------------------------------------------------
+PS1i = R127i.y;
+// 6
+PV0i.x = floatBitsToInt(intBitsToFloat(R126i.w) + intBitsToFloat(PV1i.y));
+PV0i.y = floatBitsToInt(intBitsToFloat(R126i.y) + intBitsToFloat(PV1i.x));
+// 7
+PV1i.x = ((intBitsToFloat(PV0i.y) >= intBitsToFloat(R127i.z))?int(0xFFFFFFFF):int(0x0));
+PV1i.y = floatBitsToInt(intBitsToFloat(PV0i.x) * intBitsToFloat(0x3daaaaab));
+// 8
+PV0i.x = floatBitsToInt(intBitsToFloat(R2i.w) + -(intBitsToFloat(PV1i.y)));
+R4i.z = ((PV1i.x == 0)?(0x3f800000):(0));
+PV0i.z = R4i.z;
+R5i.w = ((PV1i.x == 0)?(0):(0x3f800000));
+PV0i.w = R5i.w;
+// 9 --- Point fo Interest
+R5i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.w), intBitsToFloat(uf_remappedPS[1].x))); // Default implmentation division took place here
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.z), intBitsToFloat(uf_remappedPS[1].x) / resX)); // Default implmentation division took place here
+PV1i.z = floatBitsToInt(max(intBitsToFloat(PV0i.x), -(intBitsToFloat(PV0i.x))));
+R3i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.z), intBitsToFloat(uf_remappedPS[1].y) / resY)); // Default implmentation division took place here
+PS1i = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.x), intBitsToFloat(PV0i.z)));
+// 10 --- Point of Interest
+R127i.x = floatBitsToInt(intBitsToFloat(PV1i.z) * intBitsToFloat(R127i.y)); // Divide looks good same as below line ----------------------------------------------------------------------
+R127i.x = clampFI32(R127i.x); // Divide looks good same as above line----------------------------------------------------------------------------------------------------
+PV0i.x = R127i.x; 
+R127i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.w),intBitsToFloat(uf_remappedPS[1].y)) + intBitsToFloat(PV1i.y))); // Default implmentation division took place here
+R127i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R1i.z),intBitsToFloat(R5i.w)) + intBitsToFloat(PS1i)));
+PV0i.z = R127i.z;
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.z), intBitsToFloat(R4i.z)));
+// 11
+R124i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R2i.x),intBitsToFloat(R5i.w)) + intBitsToFloat(PV0i.w)));
+PV1i.x = R124i.x;
+PV1i.y = floatBitsToInt(-(intBitsToFloat(R2i.w)) + intBitsToFloat(PV0i.z));
+R123i.w = floatBitsToInt((intBitsToFloat(PV0i.x) * intBitsToFloat(0x40c00000) + intBitsToFloat(0xc1700000)));
+PV1i.w = R123i.w;
+// 12
+R125i.x = floatBitsToInt(max(intBitsToFloat(PV1i.y), -(intBitsToFloat(PV1i.y))));
+PV0i.y = floatBitsToInt(-(intBitsToFloat(R2i.w)) + intBitsToFloat(PV1i.x));
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.x),intBitsToFloat(PV1i.w)) + intBitsToFloat(0x41200000)));
+PV0i.z = R123i.z;
+// 13
+R126i.x = floatBitsToInt(max(intBitsToFloat(PV0i.y), -(intBitsToFloat(PV0i.y))));
+PV1i.x = R126i.x;
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(PV0i.z)));
+// 14
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(PV1i.y)));
+R126i.w = ((intBitsToFloat(R125i.x) >= intBitsToFloat(PV1i.x))?int(0xFFFFFFFF):int(0x0));
+PV0i.w = R126i.w;
+// 15
+R6i.x = floatBitsToInt(((PV0i.w == 0)?(intBitsToFloat(R127i.y)):(-(intBitsToFloat(R127i.y)))));
+PV1i.x = R6i.x;
+R123i.z = ((PV0i.w == 0)?(R126i.x):(R125i.x));
+PV1i.z = R123i.z;
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(PV0i.x)));
+// 16 --- Point of Interest
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R4i.z), intBitsToFloat(PV1i.x)));
+PV0i.x = floatBitsToInt(intBitsToFloat(PV0i.x) / 2.0); // Important Doubling improves curves and clarity
+R123i.y = ((R126i.w == 0)?(R124i.x):(R127i.z));
+PV0i.y = R123i.y;
+R3i.z = floatBitsToInt(intBitsToFloat(PV1i.w) * intBitsToFloat(0x3f400000));
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.w), intBitsToFloat(PV1i.x)));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV0i.w) / 2.0);
+R4i.x = floatBitsToInt(intBitsToFloat(PV1i.z) * 0.25);
+PS0i = R4i.x;
+// 17
+backupReg0i = R0i.x;
+PV1i.x = floatBitsToInt(intBitsToFloat(backupReg0i) + intBitsToFloat(PV0i.x));
+PV1i.z = floatBitsToInt(intBitsToFloat(R0i.y) + intBitsToFloat(PV0i.w));
+R4i.w = floatBitsToInt(intBitsToFloat(R2i.w) + intBitsToFloat(PV0i.y));
+R4i.w = floatBitsToInt(intBitsToFloat(R4i.w) / 2.0);
+PV1i.w = R4i.w;
+// 18
+R3i.x = floatBitsToInt(-(intBitsToFloat(R5i.x)) + intBitsToFloat(PV1i.x));
+R3i.y = floatBitsToInt(-(intBitsToFloat(R3i.w)) + intBitsToFloat(PV1i.z));
+R1i.z = floatBitsToInt(intBitsToFloat(R5i.x) + intBitsToFloat(PV1i.x));
+R1i.w = floatBitsToInt(intBitsToFloat(R3i.w) + intBitsToFloat(PV1i.z));
+R2i.x = floatBitsToInt(intBitsToFloat(R2i.w) + -(intBitsToFloat(PV1i.w)));
+PS0i = R2i.x;
+}
+if( activeMaskStackC[2] == true ) {
+R1i.y = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R3i.xy)).x);
+R1i.x = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+backupReg0i = R2i.x;
+R2i.x = ((0.0 > intBitsToFloat(backupReg0i))?int(0xFFFFFFFF):int(0x0));
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.x));
+PV0i.w = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.y));
+// 1
+PV1i.y = floatBitsToInt(max(intBitsToFloat(PV0i.w), -(intBitsToFloat(PV0i.w))));
+PV1i.z = floatBitsToInt(max(intBitsToFloat(PV0i.z), -(intBitsToFloat(PV0i.z))));
+// 2
+PV0i.x = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.y)));
+PV0i.y = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.z)));
+// 3
+R123i.z = ((intBitsToFloat(PV0i.y) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R123i.z;
+R123i.w = ((intBitsToFloat(PV0i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R123i.w;
+// 4
+backupReg0i = R3i.x;
+backupReg1i = R3i.y;
+R3i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R5i.x)),intBitsToFloat(PV1i.w)) + intBitsToFloat(backupReg0i)));
+R3i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R3i.w)),intBitsToFloat(PV1i.w)) + intBitsToFloat(backupReg1i)));
+R2i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.x),intBitsToFloat(PV1i.z)) + intBitsToFloat(R1i.z)));
+R2i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R3i.w),intBitsToFloat(PV1i.z)) + intBitsToFloat(R1i.w)));
+}
+if( activeMaskStackC[2] == true ) {
+R1i.w = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R3i.xy)).x);
+R1i.z = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R2i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.x = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.w));
+PV0i.y = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.z));
+// 1
+PV1i.x = floatBitsToInt(max(intBitsToFloat(PV0i.y), -(intBitsToFloat(PV0i.y))));
+PV1i.w = floatBitsToInt(max(intBitsToFloat(PV0i.x), -(intBitsToFloat(PV0i.x))));
+// 2
+PV0i.z = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.w)));
+PV0i.w = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.x)));
+// 3
+R123i.z = ((intBitsToFloat(PV0i.w) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R123i.z;
+R123i.w = ((intBitsToFloat(PV0i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R123i.w;
+// 4
+backupReg0i = R2i.z;
+backupReg1i = R2i.w;
+R1i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R5i.x)),intBitsToFloat(PV1i.w)) + intBitsToFloat(R3i.x)));
+R1i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R3i.w)),intBitsToFloat(PV1i.w)) + intBitsToFloat(R3i.y)));
+R2i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.x),intBitsToFloat(PV1i.z)) + intBitsToFloat(backupReg0i)));
+R2i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R3i.w),intBitsToFloat(PV1i.z)) + intBitsToFloat(backupReg1i)));
+}
+if( activeMaskStackC[2] == true ) {
+R3i.y = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.xy)).x);
+R3i.x = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R2i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.x = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R3i.y));
+PV0i.w = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R3i.x));
+// 1
+PV1i.z = floatBitsToInt(max(intBitsToFloat(PV0i.w), -(intBitsToFloat(PV0i.w))));
+PV1i.w = floatBitsToInt(max(intBitsToFloat(PV0i.x), -(intBitsToFloat(PV0i.x))));
+// 2
+PV0i.y = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.z)));
+PV0i.z = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.w)));
+// 3
+R123i.y = ((intBitsToFloat(PV0i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.y = R123i.y;
+R123i.z = ((intBitsToFloat(PV0i.y) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R123i.z;
+// 4
+backupReg0i = R1i.x;
+backupReg1i = R1i.y;
+R1i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R5i.x)),intBitsToFloat(PV1i.y)) + intBitsToFloat(backupReg0i)));
+R1i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R3i.w)),intBitsToFloat(PV1i.y)) + intBitsToFloat(backupReg1i)));
+R1i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.x),intBitsToFloat(PV1i.z)) + intBitsToFloat(R2i.z)));
+R1i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R3i.w),intBitsToFloat(PV1i.z)) + intBitsToFloat(R2i.w)));
+}
+if( activeMaskStackC[2] == true ) {
+R2i.w = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.xy)).x);
+R2i.z = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.x = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R2i.w));
+PV0i.y = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R2i.z));
+// 1
+PV1i.x = floatBitsToInt(max(intBitsToFloat(PV0i.y), -(intBitsToFloat(PV0i.y))));
+PV1i.w = floatBitsToInt(max(intBitsToFloat(PV0i.x), -(intBitsToFloat(PV0i.x))));
+// 2
+PV0i.z = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.w)));
+PV0i.w = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.x)));
+// 3
+R123i.z = ((intBitsToFloat(PV0i.w) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R123i.z;
+R123i.w = ((intBitsToFloat(PV0i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R123i.w;
+// 4
+backupReg0i = R1i.z;
+backupReg1i = R1i.w;
+R3i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R5i.x)),intBitsToFloat(PV1i.w)) + intBitsToFloat(R1i.x)));
+R3i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R3i.w)),intBitsToFloat(PV1i.w)) + intBitsToFloat(R1i.y)));
+R1i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.x),intBitsToFloat(PV1i.z)) + intBitsToFloat(backupReg0i)));
+R1i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R3i.w),intBitsToFloat(PV1i.z)) + intBitsToFloat(backupReg1i)));
+}
+if( activeMaskStackC[2] == true ) {
+R1i.y = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R3i.xy)).x);
+R1i.x = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.x = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.y));
+PV0i.w = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.x));
+// 1
+PV1i.z = floatBitsToInt(max(intBitsToFloat(PV0i.w), -(intBitsToFloat(PV0i.w))));
+PV1i.w = floatBitsToInt(max(intBitsToFloat(PV0i.x), -(intBitsToFloat(PV0i.x))));
+// 2
+PV0i.y = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.z)));
+PV0i.z = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.w)));
+// 3
+R123i.y = ((intBitsToFloat(PV0i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.y = R123i.y;
+R123i.z = ((intBitsToFloat(PV0i.y) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R123i.z;
+// 4
+backupReg0i = R3i.x;
+backupReg1i = R3i.y;
+R3i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R5i.x)),intBitsToFloat(PV1i.y)) + intBitsToFloat(backupReg0i)));
+R3i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R3i.w)),intBitsToFloat(PV1i.y)) + intBitsToFloat(backupReg1i)));
+R2i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.x),intBitsToFloat(PV1i.z)) + intBitsToFloat(R1i.z)));
+R2i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R3i.w),intBitsToFloat(PV1i.z)) + intBitsToFloat(R1i.w)));
+}
+if( activeMaskStackC[2] == true ) {
+R1i.w = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R3i.xy)).x);
+R1i.z = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R2i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.x = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.w));
+PV0i.y = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.z));
+// 1
+PV1i.x = floatBitsToInt(max(intBitsToFloat(PV0i.y), -(intBitsToFloat(PV0i.y))));
+PV1i.w = floatBitsToInt(max(intBitsToFloat(PV0i.x), -(intBitsToFloat(PV0i.x))));
+// 2
+PV0i.z = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.w)));
+PV0i.w = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.x)));
+// 3
+R123i.z = ((intBitsToFloat(PV0i.w) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R123i.z;
+R123i.w = ((intBitsToFloat(PV0i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R123i.w;
+// 4
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.w)));
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.z)));
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.z)));
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.w)));
+// 5
+backupReg0i = R2i.z;
+backupReg1i = R2i.w;
+R1i.x = floatBitsToInt((-(intBitsToFloat(PV0i.x)) * 1.5 + intBitsToFloat(R3i.x)));
+R1i.y = floatBitsToInt((-(intBitsToFloat(PV0i.w)) * 1.5 + intBitsToFloat(R3i.y)));
+R2i.z = floatBitsToInt((intBitsToFloat(PV0i.z) * 1.5 + intBitsToFloat(backupReg0i)));
+R2i.w = floatBitsToInt((intBitsToFloat(PV0i.y) * 1.5 + intBitsToFloat(backupReg1i)));
+}
+if( activeMaskStackC[2] == true ) {
+R3i.y = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.xy)).x);
+R3i.x = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R2i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R3i.y));
+PV0i.w = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R3i.x));
+// 1
+PV1i.y = floatBitsToInt(max(intBitsToFloat(PV0i.z), -(intBitsToFloat(PV0i.z))));
+PV1i.z = floatBitsToInt(max(intBitsToFloat(PV0i.w), -(intBitsToFloat(PV0i.w))));
+// 2
+PV0i.x = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.y)));
+PV0i.y = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.z)));
+// 3
+R123i.x = ((intBitsToFloat(PV0i.y) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.x = R123i.x;
+R123i.w = ((intBitsToFloat(PV0i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R123i.w;
+// 4
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.x)));
+PV0i.x = floatBitsToInt(intBitsToFloat(PV0i.x) * 2.0);
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.x)));
+PV0i.y = floatBitsToInt(intBitsToFloat(PV0i.y) * 2.0);
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.w)));
+PV0i.z = floatBitsToInt(intBitsToFloat(PV0i.z) * 2.0);
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.w)));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV0i.w) * 2.0);
+// 5
+backupReg0i = R1i.x;
+backupReg1i = R1i.y;
+R1i.xyz = floatBitsToInt(vec3(intBitsToFloat(backupReg0i),intBitsToFloat(backupReg1i),intBitsToFloat(R2i.z)) + vec3(-(intBitsToFloat(PV0i.w)),-(intBitsToFloat(PV0i.z)),intBitsToFloat(PV0i.x)));
+R1i.w = floatBitsToInt(intBitsToFloat(R2i.w) + intBitsToFloat(PV0i.y));
+}
+if( activeMaskStackC[2] == true ) {
+R2i.w = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.xy)).x);
+R2i.z = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.y = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R2i.z));
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R2i.w));
+// 1
+PV1i.x = floatBitsToInt(max(intBitsToFloat(PV0i.y), -(intBitsToFloat(PV0i.y))));
+PV1i.y = floatBitsToInt(max(intBitsToFloat(PV0i.z), -(intBitsToFloat(PV0i.z))));
+// 2
+PV0i.x = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.y)));
+PV0i.w = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.x)));
+// 3
+R123i.z = ((intBitsToFloat(PV0i.w) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R123i.z;
+R123i.w = ((intBitsToFloat(PV0i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R123i.w;
+// 4
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.w)));
+PV0i.x = floatBitsToInt(intBitsToFloat(PV0i.x) * 2.0);
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.z)));
+PV0i.y = floatBitsToInt(intBitsToFloat(PV0i.y) * 2.0);
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.z)));
+PV0i.z = floatBitsToInt(intBitsToFloat(PV0i.z) * 2.0);
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.w)));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV0i.w) * 2.0);
+// 5
+backupReg0i = R1i.z;
+backupReg1i = R1i.w;
+R3i.x = floatBitsToInt(intBitsToFloat(R1i.x) + -(intBitsToFloat(PV0i.x)));
+R3i.y = floatBitsToInt(intBitsToFloat(R1i.y) + -(intBitsToFloat(PV0i.w)));
+R1i.z = floatBitsToInt(intBitsToFloat(backupReg0i) + intBitsToFloat(PV0i.z));
+R1i.w = floatBitsToInt(intBitsToFloat(backupReg1i) + intBitsToFloat(PV0i.y));
+}
+if( activeMaskStackC[2] == true ) {
+R1i.y = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R3i.xy)).x);
+R1i.x = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.y));
+PV0i.w = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.x));
+// 1
+PV1i.y = floatBitsToInt(max(intBitsToFloat(PV0i.z), -(intBitsToFloat(PV0i.z))));
+PV1i.z = floatBitsToInt(max(intBitsToFloat(PV0i.w), -(intBitsToFloat(PV0i.w))));
+// 2
+PV0i.x = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.y)));
+PV0i.y = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.z)));
+// 3
+R123i.x = ((intBitsToFloat(PV0i.y) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.x = R123i.x;
+R123i.w = ((intBitsToFloat(PV0i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R123i.w;
+// 4
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.x)));
+PV0i.x = floatBitsToInt(intBitsToFloat(PV0i.x) * 2.0);
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.x)));
+PV0i.y = floatBitsToInt(intBitsToFloat(PV0i.y) * 2.0);
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.w)));
+PV0i.z = floatBitsToInt(intBitsToFloat(PV0i.z) * 2.0);
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.w)));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV0i.w) * 2.0);
+// 5
+backupReg0i = R3i.x;
+backupReg1i = R3i.y;
+R3i.x = floatBitsToInt(intBitsToFloat(backupReg0i) + -(intBitsToFloat(PV0i.w)));
+R3i.y = floatBitsToInt(intBitsToFloat(backupReg1i) + -(intBitsToFloat(PV0i.z)));
+R2i.z = floatBitsToInt(intBitsToFloat(R1i.z) + intBitsToFloat(PV0i.x));
+R2i.w = floatBitsToInt(intBitsToFloat(R1i.w) + intBitsToFloat(PV0i.y));
+}
+if( activeMaskStackC[2] == true ) {
+R1i.w = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R3i.xy)).x);
+R1i.z = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R2i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.y = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.z));
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.w));
+// 1
+PV1i.x = floatBitsToInt(max(intBitsToFloat(PV0i.y), -(intBitsToFloat(PV0i.y))));
+PV1i.y = floatBitsToInt(max(intBitsToFloat(PV0i.z), -(intBitsToFloat(PV0i.z))));
+// 2
+PV0i.x = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.y)));
+PV0i.w = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.x)));
+// 3
+R123i.z = ((intBitsToFloat(PV0i.w) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R123i.z;
+R123i.w = ((intBitsToFloat(PV0i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R123i.w;
+// 4
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.w)));
+PV0i.x = floatBitsToInt(intBitsToFloat(PV0i.x) * 2.0);
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.z)));
+PV0i.y = floatBitsToInt(intBitsToFloat(PV0i.y) * 2.0);
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.z)));
+PV0i.z = floatBitsToInt(intBitsToFloat(PV0i.z) * 2.0);
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.w)));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV0i.w) * 2.0);
+// 5
+backupReg0i = R2i.z;
+backupReg1i = R2i.w;
+R1i.x = floatBitsToInt(intBitsToFloat(R3i.x) + -(intBitsToFloat(PV0i.x)));
+R1i.y = floatBitsToInt(intBitsToFloat(R3i.y) + -(intBitsToFloat(PV0i.w)));
+R2i.z = floatBitsToInt(intBitsToFloat(backupReg0i) + intBitsToFloat(PV0i.z));
+R2i.w = floatBitsToInt(intBitsToFloat(backupReg1i) + intBitsToFloat(PV0i.y));
+}
+if( activeMaskStackC[2] == true ) {
+R3i.y = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.xy)).x);
+R3i.x = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R2i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R3i.y));
+PV0i.w = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R3i.x));
+// 1
+PV1i.y = floatBitsToInt(max(intBitsToFloat(PV0i.z), -(intBitsToFloat(PV0i.z))));
+PV1i.z = floatBitsToInt(max(intBitsToFloat(PV0i.w), -(intBitsToFloat(PV0i.w))));
+// 2
+PV0i.x = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.y)));
+PV0i.y = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.z)));
+// 3
+R123i.x = ((intBitsToFloat(PV0i.y) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.x = R123i.x;
+R123i.w = ((intBitsToFloat(PV0i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R123i.w;
+// 4
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.x)));
+PV0i.x = floatBitsToInt(intBitsToFloat(PV0i.x) * 4.0);
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.x)));
+PV0i.y = floatBitsToInt(intBitsToFloat(PV0i.y) * 4.0);
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.w)));
+PV0i.z = floatBitsToInt(intBitsToFloat(PV0i.z) * 4.0);
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.w)));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV0i.w) * 4.0);
+// 5
+backupReg0i = R1i.x;
+backupReg1i = R1i.y;
+R1i.xyz = floatBitsToInt(vec3(intBitsToFloat(backupReg0i),intBitsToFloat(backupReg1i),intBitsToFloat(R2i.z)) + vec3(-(intBitsToFloat(PV0i.w)),-(intBitsToFloat(PV0i.z)),intBitsToFloat(PV0i.x)));
+R1i.w = floatBitsToInt(intBitsToFloat(R2i.w) + intBitsToFloat(PV0i.y));
+}
+if( activeMaskStackC[2] == true ) {
+R2i.w = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.xy)).x);
+R2i.z = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.y = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R2i.z));
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R2i.w));
+// 1
+PV1i.x = floatBitsToInt(max(intBitsToFloat(PV0i.y), -(intBitsToFloat(PV0i.y))));
+PV1i.y = floatBitsToInt(max(intBitsToFloat(PV0i.z), -(intBitsToFloat(PV0i.z))));
+// 2
+PV0i.x = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.y)));
+PV0i.w = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.x)));
+// 3
+R123i.z = ((intBitsToFloat(PV0i.w) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R123i.z;
+R123i.w = ((intBitsToFloat(PV0i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R123i.w;
+// 4
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.w)));
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.z)));
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.z)));
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.w)));
+// 5
+backupReg0i = R1i.z;
+backupReg1i = R1i.w;
+R5i.x = floatBitsToInt((-(intBitsToFloat(PV0i.x)) * intBitsToFloat(0x41000000) + intBitsToFloat(R1i.x)));
+R5i.y = floatBitsToInt((-(intBitsToFloat(PV0i.w)) * intBitsToFloat(0x41000000) + intBitsToFloat(R1i.y)));
+R1i.z = floatBitsToInt((intBitsToFloat(PV0i.y) * intBitsToFloat(0x41000000) + intBitsToFloat(backupReg0i)));
+R1i.w = floatBitsToInt((intBitsToFloat(PV0i.z) * intBitsToFloat(0x41000000) + intBitsToFloat(backupReg1i)));
+}
+if( activeMaskStackC[2] == true ) {
+R1i.y = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R5i.xy)).x);
+R1i.x = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+backupReg0i = R0i.x;
+backupReg1i = R0i.y;
+backupReg0i = R0i.x;
+PV0i.x = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.x));
+PV0i.y = floatBitsToInt(intBitsToFloat(backupReg0i) + -(intBitsToFloat(R5i.x)));
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.y));
+R126i.w = floatBitsToInt(intBitsToFloat(backupReg1i) + -(intBitsToFloat(R5i.y)));
+PS0i = floatBitsToInt(-(intBitsToFloat(backupReg0i)) + intBitsToFloat(R1i.z));
+// 1
+PV1i.x = floatBitsToInt(-(intBitsToFloat(R0i.y)) + intBitsToFloat(R1i.w));
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.w), intBitsToFloat(PS0i)));
+PV1i.z = ((0.0 > intBitsToFloat(PV0i.z))?int(0xFFFFFFFF):int(0x0));
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.w), intBitsToFloat(PV0i.y)));
+PS1i = ((0.0 > intBitsToFloat(PV0i.x))?int(0xFFFFFFFF):int(0x0));
+// 2
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R4i.z),intBitsToFloat(PV1i.x)) + intBitsToFloat(PV1i.y)));
+PV0i.x = R123i.x;
+R127i.y = (PV1i.z != R2i.x)?int(0xFFFFFFFF):int(0x0);
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R4i.z),intBitsToFloat(R126i.w)) + intBitsToFloat(PV1i.w)));
+PV0i.z = R123i.z;
+R126i.w = (PS1i != R2i.x)?int(0xFFFFFFFF):int(0x0);
+// 3
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.z) + intBitsToFloat(PV0i.x));
+R126i.y = floatBitsToInt(min(intBitsToFloat(PV0i.z), intBitsToFloat(PV0i.x)));
+PV1i.z = ((intBitsToFloat(PV0i.x) > intBitsToFloat(PV0i.z))?int(0xFFFFFFFF):int(0x0));
+// 4
+backupReg0i = R127i.y;
+R127i.y = ((PV1i.z == 0)?(R126i.w):(backupReg0i));
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PV1i.x));
+// 5
+PV1i.z = floatBitsToInt(intBitsToFloat(R126i.y) * intBitsToFloat(PS0i));
+// 6
+PV0i.y = floatBitsToInt(-(intBitsToFloat(PV1i.z)) + 0.5);
+// 7
+R123i.x = ((R127i.y == 0)?(0):(PV0i.y));
+PV1i.x = R123i.x;
+// 8
+PV0i.w = floatBitsToInt(max(intBitsToFloat(R3i.z), intBitsToFloat(PV1i.x)));
+// 9
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R6i.x), intBitsToFloat(PV0i.w)));
+// 10
+backupReg0i = R0i.x;
+backupReg1i = R0i.y;
+R0i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R4i.z),intBitsToFloat(PV1i.z)) + intBitsToFloat(backupReg0i)));
+R0i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.w),intBitsToFloat(PV1i.z)) + intBitsToFloat(backupReg1i)));
+}
+if( activeMaskStackC[2] == true ) {
+R3i.xyzw = floatBitsToInt(texture(textureUnitPS0, intBitsToFloat(R0i.xy)).xyzw);
+}
+activeMaskStackC[1] = activeMaskStack[0] == true && activeMaskStackC[0] == true;
+// export
+passPixelColor0 = vec4(intBitsToFloat(R3i.x), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.w));
+}
+
+#elif (fxaa == 2) // NVIDIA FXAA
+
+//-----------------------------settings-------------------------------------//
+
+#define Subpix               $subPix  //[0.000 to 1.000] Choose the amount of sub-pixel aliasing removal.
+#define EdgeThreshold        $edgeThreshold  //[0.000 to 1.000] Edge detection threshold. The minimum amount of local contrast required to apply algorithm.
+#define EdgeThresholdMin     $edgeThresholdMin  //[0.000 to 1.000] Darkness threshold. Trims the algorithm from processing darks.
+
+//--------------------------------------------------------------------------//
+
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
+layout(location = 0) in vec4 passParameterSem2;
+layout(location = 0) out vec4 passPixelColor0;
+
+
+#define FXAA_QUALITY_PS 12
+#define FXAA_QUALITY_P0 1.0
+#define FXAA_QUALITY_P1 1.0
+#define FXAA_QUALITY_P2 1.0
+#define FXAA_QUALITY_P3 1.0
+#define FXAA_QUALITY_P4 1.0
+#define FXAA_QUALITY_P5 1.5
+#define FXAA_QUALITY_P6 2.0
+#define FXAA_QUALITY_P7 2.0
+#define FXAA_QUALITY_P8 2.0
+#define FXAA_QUALITY_P9 2.0
+#define FXAA_QUALITY_P10 4.0
+#define FXAA_QUALITY_P11 8.0
+
+#define FxaaBool bool
+#define FxaaDiscard discard
+#define FxaaFloat float
+#define FxaaFloat2 vec2
+#define FxaaFloat3 vec3
+#define FxaaFloat4 vec4
+#define FxaaHalf float
+#define FxaaHalf2 vec2
+#define FxaaHalf3 vec3
+#define FxaaHalf4 vec4
+#define FxaaInt2 ivec2
+#define FxaaSat(x) clamp(x, 0.0, 1.0)
+#define FxaaTex sampler2D
+
+#define FxaaTexTop(t, p) textureLod(t, p, 0.0)
+#define FxaaTexOff(t, p, o, r) textureLodOffset(t, p, 0.0, o)
+
+#define FxaaTexAlpha4(t, p) textureGather(t, p, 3)
+#define FxaaTexOffAlpha4(t, p, o) textureGatherOffset(t, p, o, 3)
+#define FxaaTexGreen4(t, p) textureGather(t, p, 1)
+#define FxaaTexOffGreen4(t, p, o) textureGatherOffset(t, p, o, 1)
+
+FxaaFloat4 FxaaPixelShader(
+    FxaaFloat2 pos,
+    FxaaTex tex,
+    FxaaTex lum,
+    FxaaFloat2 fxaaQualityRcpFrame,
+    FxaaFloat fxaaQualitySubpix,
+    FxaaFloat fxaaQualityEdgeThreshold,
+    FxaaFloat fxaaQualityEdgeThresholdMin
+) {
+    FxaaFloat2 posM;
+    posM.x = pos.x;
+    posM.y = pos.y;
+	FxaaFloat4 rgbyM = vec4(FxaaTexTop(tex, posM).xyz, FxaaTexTop(lum, posM).x);
+	#define lumaM rgbyM.w
+    FxaaFloat4 luma4A = textureGather(lum, posM);
+    FxaaFloat4 luma4B = textureGatherOffset(lum, posM, FxaaInt2(-1, -1));
+    #define lumaE luma4A.z
+    #define lumaS luma4A.x
+    #define lumaSE luma4A.y
+    #define lumaNW luma4B.w
+    #define lumaN luma4B.z
+    #define lumaW luma4B.x
+    FxaaFloat maxSM = max(lumaS, lumaM);
+    FxaaFloat minSM = min(lumaS, lumaM);
+    FxaaFloat maxESM = max(lumaE, maxSM);
+    FxaaFloat minESM = min(lumaE, minSM);
+    FxaaFloat maxWN = max(lumaN, lumaW);
+    FxaaFloat minWN = min(lumaN, lumaW);
+    FxaaFloat rangeMax = max(maxWN, maxESM);
+    FxaaFloat rangeMin = min(minWN, minESM);
+    FxaaFloat rangeMaxScaled = rangeMax * fxaaQualityEdgeThreshold;
+    FxaaFloat range = rangeMax - rangeMin;
+    FxaaFloat rangeMaxClamped = max(fxaaQualityEdgeThresholdMin, rangeMaxScaled);
+    FxaaBool earlyExit = range < rangeMaxClamped;
+    if(earlyExit)
+        return rgbyM;
+    FxaaFloat lumaNE = FxaaTexOff(lum, posM, FxaaInt2(1, -1), fxaaQualityRcpFrame.xy).x;
+    FxaaFloat lumaSW = FxaaTexOff(lum, posM, FxaaInt2(-1, 1), fxaaQualityRcpFrame.xy).x;
+    FxaaFloat lumaNS = lumaN + lumaS;
+    FxaaFloat lumaWE = lumaW + lumaE;
+    FxaaFloat subpixRcpRange = 1.0/range;
+    FxaaFloat subpixNSWE = lumaNS + lumaWE;
+    FxaaFloat edgeHorz1 = (-2.0 * lumaM) + lumaNS;
+    FxaaFloat edgeVert1 = (-2.0 * lumaM) + lumaWE;
+    FxaaFloat lumaNESE = lumaNE + lumaSE;
+    FxaaFloat lumaNWNE = lumaNW + lumaNE;
+    FxaaFloat edgeHorz2 = (-2.0 * lumaE) + lumaNESE;
+    FxaaFloat edgeVert2 = (-2.0 * lumaN) + lumaNWNE;
+    FxaaFloat lumaNWSW = lumaNW + lumaSW;
+    FxaaFloat lumaSWSE = lumaSW + lumaSE;
+    FxaaFloat edgeHorz4 = (abs(edgeHorz1) * 2.0) + abs(edgeHorz2);
+    FxaaFloat edgeVert4 = (abs(edgeVert1) * 2.0) + abs(edgeVert2);
+    FxaaFloat edgeHorz3 = (-2.0 * lumaW) + lumaNWSW;
+    FxaaFloat edgeVert3 = (-2.0 * lumaS) + lumaSWSE;
+    FxaaFloat edgeHorz = abs(edgeHorz3) + edgeHorz4;
+    FxaaFloat edgeVert = abs(edgeVert3) + edgeVert4;
+    FxaaFloat subpixNWSWNESE = lumaNWSW + lumaNESE;
+    FxaaFloat lengthSign = fxaaQualityRcpFrame.x;
+    FxaaBool horzSpan = edgeHorz >= edgeVert;
+    FxaaFloat subpixA = subpixNSWE * 2.0 + subpixNWSWNESE;
+    if(!horzSpan) lumaN = lumaW;
+    if(!horzSpan) lumaS = lumaE;
+    if(horzSpan) lengthSign = fxaaQualityRcpFrame.y;
+    FxaaFloat subpixB = (subpixA * (1.0/12.0)) - lumaM;
+    FxaaFloat gradientN = lumaN - lumaM;
+    FxaaFloat gradientS = lumaS - lumaM;
+    FxaaFloat lumaNN = lumaN + lumaM;
+    FxaaFloat lumaSS = lumaS + lumaM;
+    FxaaBool pairN = abs(gradientN) >= abs(gradientS);
+    FxaaFloat gradient = max(abs(gradientN), abs(gradientS));
+    if(pairN) lengthSign = -lengthSign;
+    FxaaFloat subpixC = FxaaSat(abs(subpixB) * subpixRcpRange);
+    FxaaFloat2 posB;
+    posB.x = posM.x;
+    posB.y = posM.y;
+    FxaaFloat2 offNP;
+    offNP.x = (!horzSpan) ? 0.0 : fxaaQualityRcpFrame.x;
+    offNP.y = ( horzSpan) ? 0.0 : fxaaQualityRcpFrame.y;
+    if(!horzSpan) posB.x += lengthSign * 0.5;
+    if( horzSpan) posB.y += lengthSign * 0.5;
+    FxaaFloat2 posN;
+    posN.x = posB.x - offNP.x * FXAA_QUALITY_P0;
+    posN.y = posB.y - offNP.y * FXAA_QUALITY_P0;
+    FxaaFloat2 posP;
+    posP.x = posB.x + offNP.x * FXAA_QUALITY_P0;
+    posP.y = posB.y + offNP.y * FXAA_QUALITY_P0;
+    FxaaFloat subpixD = ((-2.0)*subpixC) + 3.0;
+    FxaaFloat lumaEndN = FxaaTexTop(lum, posN).x;
+    FxaaFloat subpixE = subpixC * subpixC;
+    FxaaFloat lumaEndP = FxaaTexTop(lum, posP).x;
+    if(!pairN) lumaNN = lumaSS;
+    FxaaFloat gradientScaled = gradient * 1.0/4.0;
+    FxaaFloat lumaMM = lumaM - lumaNN * 0.5;
+    FxaaFloat subpixF = subpixD * subpixE;
+    FxaaBool lumaMLTZero = lumaMM < 0.0;
+    lumaEndN -= lumaNN * 0.5;
+    lumaEndP -= lumaNN * 0.5;
+    FxaaBool doneN = abs(lumaEndN) >= gradientScaled;
+    FxaaBool doneP = abs(lumaEndP) >= gradientScaled;
+    if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P1;
+    if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P1;
+    FxaaBool doneNP = (!doneN) || (!doneP);
+    if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P1;
+    if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P1;
+    if(doneNP) {
+        if(!doneN) lumaEndN = FxaaTexTop(lum, posN.xy).x;
+        if(!doneP) lumaEndP = FxaaTexTop(lum, posP.xy).x;
+        if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+        if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+        doneN = abs(lumaEndN) >= gradientScaled;
+        doneP = abs(lumaEndP) >= gradientScaled;
+        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P2;
+        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P2;
+        doneNP = (!doneN) || (!doneP);
+        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P2;
+        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P2;
+        #if (FXAA_QUALITY_PS > 3)
+        if(doneNP) {
+            if(!doneN) lumaEndN = FxaaTexTop(lum, posN.xy).x;
+            if(!doneP) lumaEndP = FxaaTexTop(lum, posP.xy).x;
+            if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+            if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+            doneN = abs(lumaEndN) >= gradientScaled;
+            doneP = abs(lumaEndP) >= gradientScaled;
+            if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P3;
+            if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P3;
+            doneNP = (!doneN) || (!doneP);
+            if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P3;
+            if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P3;
+            #if (FXAA_QUALITY_PS > 4)
+            if(doneNP) {
+                if(!doneN) lumaEndN = FxaaTexTop(lum, posN.xy).x;
+                if(!doneP) lumaEndP = FxaaTexTop(lum, posP.xy).x;
+                if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                doneN = abs(lumaEndN) >= gradientScaled;
+                doneP = abs(lumaEndP) >= gradientScaled;
+                if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P4;
+                if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P4;
+                doneNP = (!doneN) || (!doneP);
+                if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P4;
+                if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P4;
+                #if (FXAA_QUALITY_PS > 5)
+                if(doneNP) {
+                    if(!doneN) lumaEndN = FxaaTexTop(lum, posN.xy).x;
+                    if(!doneP) lumaEndP = FxaaTexTop(lum, posP.xy).x;
+                    if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                    if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                    doneN = abs(lumaEndN) >= gradientScaled;
+                    doneP = abs(lumaEndP) >= gradientScaled;
+                    if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P5;
+                    if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P5;
+                    doneNP = (!doneN) || (!doneP);
+                    if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P5;
+                    if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P5;
+                    #if (FXAA_QUALITY_PS > 6)
+                    if(doneNP) {
+                        if(!doneN) lumaEndN = FxaaTexTop(lum, posN.xy).x;
+                        if(!doneP) lumaEndP = FxaaTexTop(lum, posP.xy).x;
+                        if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                        if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                        doneN = abs(lumaEndN) >= gradientScaled;
+                        doneP = abs(lumaEndP) >= gradientScaled;
+                        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P6;
+                        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P6;
+                        doneNP = (!doneN) || (!doneP);
+                        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P6;
+                        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P6;
+                        #if (FXAA_QUALITY_PS > 7)
+                        if(doneNP) {
+                            if(!doneN) lumaEndN = FxaaTexTop(lum, posN.xy).x;
+                            if(!doneP) lumaEndP = FxaaTexTop(lum, posP.xy).x;
+                            if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                            if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                            doneN = abs(lumaEndN) >= gradientScaled;
+                            doneP = abs(lumaEndP) >= gradientScaled;
+                            if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P7;
+                            if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P7;
+                            doneNP = (!doneN) || (!doneP);
+                            if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P7;
+                            if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P7;
+    #if (FXAA_QUALITY_PS > 8)
+    if(doneNP) {
+        if(!doneN) lumaEndN = FxaaTexTop(lum, posN.xy).x;
+        if(!doneP) lumaEndP = FxaaTexTop(lum, posP.xy).x;
+        if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+        if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+        doneN = abs(lumaEndN) >= gradientScaled;
+        doneP = abs(lumaEndP) >= gradientScaled;
+        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P8;
+        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P8;
+        doneNP = (!doneN) || (!doneP);
+        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P8;
+        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P8;
+        #if (FXAA_QUALITY_PS > 9)
+        if(doneNP) {
+            if(!doneN) lumaEndN = FxaaTexTop(lum, posN.xy).x;
+            if(!doneP) lumaEndP = FxaaTexTop(lum, posP.xy).x;
+            if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+            if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+            doneN = abs(lumaEndN) >= gradientScaled;
+            doneP = abs(lumaEndP) >= gradientScaled;
+            if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P9;
+            if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P9;
+            doneNP = (!doneN) || (!doneP);
+            if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P9;
+            if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P9;
+            #if (FXAA_QUALITY_PS > 10)
+            if(doneNP) {
+                if(!doneN) lumaEndN = FxaaTexTop(lum, posN.xy).x;
+                if(!doneP) lumaEndP = FxaaTexTop(lum, posP.xy).x;
+                if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                doneN = abs(lumaEndN) >= gradientScaled;
+                doneP = abs(lumaEndP) >= gradientScaled;
+                if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P10;
+                if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P10;
+                doneNP = (!doneN) || (!doneP);
+                if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P10;
+                if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P10;
+                #if (FXAA_QUALITY_PS > 11)
+                if(doneNP) {
+                    if(!doneN) lumaEndN = FxaaTexTop(lum, posN.xy).x;
+                    if(!doneP) lumaEndP = FxaaTexTop(lum, posP.xy).x;
+                    if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                    if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                    doneN = abs(lumaEndN) >= gradientScaled;
+                    doneP = abs(lumaEndP) >= gradientScaled;
+                    if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P11;
+                    if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P11;
+                    doneNP = (!doneN) || (!doneP);
+                    if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P11;
+                    if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P11;
+                    #if (FXAA_QUALITY_PS > 12)
+                    if(doneNP) {
+                        if(!doneN) lumaEndN = FxaaTexTop(lum, posN.xy).x;
+                        if(!doneP) lumaEndP = FxaaTexTop(lum, posP.xy).x;
+                        if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                        if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                        doneN = abs(lumaEndN) >= gradientScaled;
+                        doneP = abs(lumaEndP) >= gradientScaled;
+                        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P12;
+                        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P12;
+                        doneNP = (!doneN) || (!doneP);
+                        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P12;
+                        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P12;
+                    }
+                    #endif
+                }
+                #endif
+            }
+            #endif
+        }
+        #endif
+    }
+    #endif
+                        }
+                        #endif
+                    }
+                    #endif
+                }
+                #endif
+            }
+            #endif
+        }
+        #endif
+    }
+    FxaaFloat dstN = posM.x - posN.x;
+    FxaaFloat dstP = posP.x - posM.x;
+    if(!horzSpan) dstN = posM.y - posN.y;
+    if(!horzSpan) dstP = posP.y - posM.y;
+    FxaaBool goodSpanN = (lumaEndN < 0.0) != lumaMLTZero;
+    FxaaFloat spanLength = (dstP + dstN);
+    FxaaBool goodSpanP = (lumaEndP < 0.0) != lumaMLTZero;
+    FxaaFloat spanLengthRcp = 1.0/spanLength;
+    FxaaBool directionN = dstN < dstP;
+    FxaaFloat dst = min(dstN, dstP);
+    FxaaBool goodSpan = directionN ? goodSpanN : goodSpanP;
+    FxaaFloat subpixG = subpixF * subpixF;
+    FxaaFloat pixelOffset = (dst * (-spanLengthRcp)) + 0.5;
+    FxaaFloat subpixH = subpixG * fxaaQualitySubpix;
+    FxaaFloat pixelOffsetGood = goodSpan ? pixelOffset : 0.0;
+    FxaaFloat pixelOffsetSubpix = max(pixelOffsetGood, subpixH);
+    if(!horzSpan) posM.x += pixelOffsetSubpix * lengthSign;
+    if( horzSpan) posM.y += pixelOffsetSubpix * lengthSign;
+    return FxaaFloat4(FxaaTexTop(tex, posM).xyz, lumaM);
+}
+
+ivec2 resolution = textureSize(textureUnitPS0,0);
+vec2 RcpFrame = vec2(1.0 / float(resolution.x), 1.0 / float(resolution.y));
+void main()
+{
+passPixelColor0 = FxaaPixelShader(passParameterSem2.xy, textureUnitPS0, textureUnitPS1, RcpFrame, Subpix, EdgeThreshold, EdgeThresholdMin);
+}
+
+#endif

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/141f484aff9b9f5a_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/141f484aff9b9f5a_0000000000000000_vs.txt
@@ -1,0 +1,102 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader 141f484aff9b9f5a
+// Used for: Anti-Aliasing Color Mix
+
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[3];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[3];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 0) out vec4 passParameterSem2;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R2f = vec4(0.0);
+vec4 R123f = vec4(0.0);
+uvec4 attrDecoder;
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = floatBitsToInt(ivec4(gl_VertexID, 0, 0, gl_InstanceID));
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R1f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(floatBitsToInt(1.0)));
+attrDecoder.xy = attrDataSem1.xy;
+attrDecoder.xy = (attrDecoder.xy>>24)|((attrDecoder.xy>>8)&0xFF00)|((attrDecoder.xy<<8)&0xFF0000)|((attrDecoder.xy<<24));
+attrDecoder.z = 0;
+attrDecoder.w = 0;
+R2f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(floatBitsToInt(0.0)), intBitsToFloat(floatBitsToInt(1.0)));
+// 0
+backupReg0f = R1f.x;
+backupReg1f = R1f.y;
+R1f.x = backupReg0f;
+R1f.x *= 2.0;
+R1f.y = backupReg1f;
+R1f.y *= 2.0;
+R1f.z = intBitsToFloat(uf_remappedVS[0].x);
+R1f.w = 1.0;
+PS0f = intBitsToFloat(uf_remappedVS[1].x) + 0.5;
+// 1
+R123f.x = (mul_nonIEEE(-(PS0f),intBitsToFloat(uf_remappedVS[2].y)/resYScale) + R2f.y);
+PV1f.x = R123f.x;
+R123f.y = (mul_nonIEEE(-(PS0f),intBitsToFloat(uf_remappedVS[2].x)/resXScale) + R2f.x);
+PV1f.y = R123f.y;
+// 2
+R2f.z = PV1f.y;
+R2f.w = PV1f.x;
+// export
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
+// export
+passParameterSem2 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/15afdae4307b9a3d_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/15afdae4307b9a3d_0000000000000000_vs.txt
@@ -1,0 +1,103 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader 15afdae4307b9a3d
+// Used for: Vertical Ambient-Occlusion Blur
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 0) out vec4 passParameterSem0;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R2f = vec4(0.0);
+uvec4 attrDecoder;
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = floatBitsToInt(ivec4(gl_VertexID, 0, 0, gl_InstanceID));
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R1f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(floatBitsToInt(1.0)));
+attrDecoder.xy = attrDataSem1.xy;
+attrDecoder.xy = (attrDecoder.xy>>24)|((attrDecoder.xy>>8)&0xFF00)|((attrDecoder.xy<<8)&0xFF0000)|((attrDecoder.xy<<24));
+attrDecoder.z = 0;
+attrDecoder.w = 0;
+R2f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(floatBitsToInt(0.0)), intBitsToFloat(floatBitsToInt(1.0)));
+// 0
+backupReg0f = R1f.x;
+backupReg1f = R1f.y;
+R1f.x = backupReg0f;
+R1f.x *= 2.0;
+R1f.y = backupReg1f;
+R1f.y *= 2.0;
+R1f.z = -(1.0);
+R1f.w = 1.0;
+R0f.x = R2f.x;
+PS0f = R0f.x;
+// 1
+backupReg0f = R2f.y;
+R0f.y = R2f.y;
+R2f.z = R2f.y + intBitsToFloat(uf_remappedVS[0].y)/resYScale;
+R2f.w = R2f.y;
+R2f.y = backupReg0f + -(intBitsToFloat(uf_remappedVS[0].y))/resYScale;
+PS1f = R2f.y;
+// export
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
+// export
+passParameterSem0 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
+// export
+// skipped export to semanticId 255
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/1a14de8e58d5b30a_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/1a14de8e58d5b30a_0000000000000000_vs.txt
@@ -1,0 +1,248 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader 1a14de8e58d5b30a
+// Used for: Restoring the native BotW Anti-Aliasing implementation
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 1) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+TEXTURE_LAYOUT(32, 0, 0) uniform sampler2D textureUnitVS0;
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 2) out vec4 passParameterSem2;
+layout(location = 3) out vec4 passParameterSem4;
+layout(location = 0) out vec4 passParameterSem0;
+layout(location = 1) out vec4 passParameterSem1;
+layout(location = 4) out vec4 passParameterSem6;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+ivec4 R0i = ivec4(0);
+ivec4 R1i = ivec4(0);
+ivec4 R2i = ivec4(0);
+ivec4 R3i = ivec4(0);
+ivec4 R4i = ivec4(0);
+ivec4 R5i = ivec4(0);
+ivec4 R123i = ivec4(0);
+ivec4 R124i = ivec4(0);
+ivec4 R125i = ivec4(0);
+ivec4 R126i = ivec4(0);
+ivec4 R127i = ivec4(0);
+uvec4 attrDecoder;
+int backupReg0i, backupReg1i, backupReg2i, backupReg3i, backupReg4i;
+ivec4 PV0i = ivec4(0), PV1i = ivec4(0);
+int PS0i = 0, PS1i = 0;
+ivec4 tempi = ivec4(0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0i = ivec4(gl_VertexID, 0, 0, gl_InstanceID);
+attrDecoder.xyzw = attrDataSem0.xyzw;
+attrDecoder = ((attrDecoder>>8)&0xFF)|((attrDecoder<<8)&0xFF00);
+attrDecoder.xyzw = floatBitsToInt(vec4(unpackHalf2x16(attrDecoder.x|(attrDecoder.y<<16)),unpackHalf2x16(attrDecoder.z|(attrDecoder.w<<16))));
+R1i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder.x = attrDataSem1.x;
+attrDecoder.x = (attrDecoder.x>>24)|((attrDecoder.x>>8)&0xFF00)|((attrDecoder.x<<8)&0xFF0000)|((attrDecoder.x<<24));
+attrDecoder.y = 0;
+attrDecoder.z = 0;
+attrDecoder.w = 0;
+attrDecoder.xyzw = uvec4((attrDecoder.x>>0)&0x3FF,(attrDecoder.x>>10)&0x3FF,(attrDecoder.x>>20)&0x3FF,(attrDecoder.x>>30)&0x3);
+if( (attrDecoder.x&0x200) != 0 ) attrDecoder.x |= 0xFFFFFC00;
+if( (attrDecoder.y&0x200) != 0 ) attrDecoder.y |= 0xFFFFFC00;
+if( (attrDecoder.z&0x200) != 0 ) attrDecoder.z |= 0xFFFFFC00;
+attrDecoder.x = floatBitsToUint(max(float(int(attrDecoder.x))/511.0,-1.0));
+attrDecoder.y = floatBitsToUint(max(float(int(attrDecoder.y))/511.0,-1.0));
+attrDecoder.z = floatBitsToUint(max(float(int(attrDecoder.z))/511.0,-1.0));
+attrDecoder.w = floatBitsToUint(float(attrDecoder.w));
+R2i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+// 0
+backupReg0i = R0i.x;
+PV0i.x = (backupReg0i == int(1))?int(0xFFFFFFFF):int(0x0);
+R127i.y = 0x3f800000;
+PV0i.z = 0x3f800000;
+PV0i.w = 0x40400000;
+R127i.z = 0xbf800000;
+PS0i = R127i.z;
+// 1
+R123i.x = ((PV0i.x == 0)?(PV0i.z):(0xc0400000));
+PV1i.x = R123i.x;
+R123i.y = ((PV0i.x == 0)?(PV0i.w):(0xbf800000));
+PV1i.y = R123i.y;
+R0i.z = 0;
+PV1i.w = floatBitsToInt(intBitsToFloat(uf_remappedVS[0].z) * intBitsToFloat(0x3b808081));
+R2i.w = 0x3f800000;
+PS1i = R2i.w;
+// 2
+R2i.x = ((R0i.x == 0)?(R127i.z):(PV1i.y));
+PV0i.x = R2i.x;
+R2i.y = ((R0i.x == 0)?(R127i.y):(PV1i.x));
+PV0i.y = R2i.y;
+R2i.z = floatBitsToInt(intBitsToFloat(PV1i.w) + -(0.5));
+R2i.z = floatBitsToInt(intBitsToFloat(R2i.z) * 2.0);
+R0i.w = 0x3ec00000;
+R0i.x = 0x3eeaaaab;
+PS0i = R0i.x;
+// 3
+R1i.x = 0x3d2aaaab;
+R0i.y = 0;
+R1i.z = 0;
+R1i.w = floatBitsToInt(-(intBitsToFloat(PV0i.y)));
+R5i.x = floatBitsToInt((intBitsToFloat(PV0i.x) * 0.5 + 0.5));
+PS1i = R5i.x;
+R3i.xyz = floatBitsToInt(texture(textureUnitVS0, intBitsToFloat(R0i.wz)).xyz);
+R0i.xyz = floatBitsToInt(texture(textureUnitVS0, intBitsToFloat(R0i.xy)).xyz);
+R4i.w = floatBitsToInt(texture(textureUnitVS0, intBitsToFloat(R1i.xz)).y);
+// export
+SET_POSITION(vec4(intBitsToFloat(R2i.x), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w)));
+// 0
+R127i.x = uf_remappedVS[1].z;
+R127i.x = floatBitsToInt(intBitsToFloat(R127i.x) / 2.0);
+PV0i.x = R127i.x;
+R5i.y = floatBitsToInt((intBitsToFloat(R1i.w) * 0.5 + 0.5));
+PV0i.y = R5i.y;
+R126i.z = floatBitsToInt(-(intBitsToFloat(uf_remappedVS[2].z)));
+R126i.z = floatBitsToInt(intBitsToFloat(R126i.z) / 2.0);
+R127i.w = R2i.x;
+R127i.w = floatBitsToInt(intBitsToFloat(R127i.w) / 2.0);
+R1i.z = R5i.x;
+PS0i = R1i.z;
+// 1
+backupReg0i = R2i.y;
+R2i.x = floatBitsToInt(-(intBitsToFloat(uf_remappedVS[3].x)));
+R2i.x = floatBitsToInt(intBitsToFloat(R2i.x) * 2.0);
+PV1i.x = R2i.x;
+R2i.y = uf_remappedVS[3].y;
+R2i.y = floatBitsToInt(intBitsToFloat(R2i.y) * 2.0);
+PV1i.y = R2i.y;
+R127i.z = floatBitsToInt(-(intBitsToFloat(backupReg0i)));
+R127i.z = floatBitsToInt(intBitsToFloat(R127i.z) / 2.0);
+R1i.w = PV0i.y;
+PV1i.w = R1i.w;
+R126i.y = floatBitsToInt(intBitsToFloat(PV0i.x) + -(0.5));
+PS1i = R126i.y;
+// 2
+backupReg0i = R127i.w;
+R126i.x = floatBitsToInt(intBitsToFloat(R126i.z) + -(0.5));
+PV0i.x = R126i.x;
+PV0i.y = floatBitsToInt(-(intBitsToFloat(PV1i.x)));
+PV0i.y = floatBitsToInt(intBitsToFloat(PV0i.y) / 2.0);
+PV0i.z = floatBitsToInt(intBitsToFloat(PV1i.w) + intBitsToFloat(uf_remappedVS[4].w)/resYScale);
+R127i.w = floatBitsToInt(-(intBitsToFloat(PV1i.y)));
+R127i.w = floatBitsToInt(intBitsToFloat(R127i.w) / 2.0);
+R127i.y = floatBitsToInt(intBitsToFloat(backupReg0i) + intBitsToFloat(R127i.x));
+PS0i = R127i.y;
+// 3
+PV1i.x = floatBitsToInt(intBitsToFloat(R127i.z) + intBitsToFloat(R126i.z));
+R125i.y = floatBitsToInt(intBitsToFloat(R5i.x) + intBitsToFloat(R126i.y));
+R127i.z = floatBitsToInt(intBitsToFloat(PV0i.z) + intBitsToFloat(PV0i.x));
+R126i.w = floatBitsToInt(intBitsToFloat(R1i.z) + intBitsToFloat(uf_remappedVS[4].z)/resXScale);
+R125i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R2i.x),intBitsToFloat(R127i.x)) + intBitsToFloat(PV0i.y)));
+PS1i = R125i.w;
+// 4
+backupReg0i = R127i.y;
+backupReg1i = R126i.z;
+R127i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.y), intBitsToFloat(PV1i.x)));
+R127i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.x), intBitsToFloat(backupReg0i)));
+R126i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R2i.y),intBitsToFloat(backupReg1i)) + intBitsToFloat(R127i.w)));
+R127i.w = floatBitsToInt(intBitsToFloat(uf_remappedVS[4].x)*resXScale);
+R127i.w = floatBitsToInt(intBitsToFloat(R127i.w) / 2.0);
+R125i.z = floatBitsToInt(intBitsToFloat(uf_remappedVS[4].y)*resYScale);
+R125i.z = floatBitsToInt(intBitsToFloat(R125i.z) / 2.0);
+PS0i = R125i.z;
+// 5
+backupReg0i = R126i.x;
+backupReg1i = R126i.w;
+backupReg2i = R126i.y;
+R126i.x = floatBitsToInt(intBitsToFloat(uf_remappedVS[4].w)/resYScale);
+R126i.x = floatBitsToInt(intBitsToFloat(R126i.x) * 2.0);
+R126i.y = floatBitsToInt(intBitsToFloat(uf_remappedVS[4].z)/resXScale);
+R126i.y = floatBitsToInt(intBitsToFloat(R126i.y) * 2.0);
+R124i.z = floatBitsToInt(intBitsToFloat(R5i.y) + intBitsToFloat(backupReg0i));
+R126i.w = floatBitsToInt(intBitsToFloat(backupReg1i) + intBitsToFloat(backupReg2i));
+R124i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.x), intBitsToFloat(R125i.y)));
+PS1i = R124i.w;
+// 6
+backupReg0i = R0i.y;
+backupReg1i = R0i.x;
+backupReg2i = R125i.w;
+PV0i.x = floatBitsToInt(-(intBitsToFloat(R3i.z)) + intBitsToFloat(R0i.z));
+PV0i.y = floatBitsToInt(-(intBitsToFloat(R3i.y)) + intBitsToFloat(backupReg0i));
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R3i.x)) + intBitsToFloat(backupReg1i));
+R125i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.y), intBitsToFloat(R127i.z)));
+R2i.z = backupReg2i;
+PS0i = R2i.z;
+// 7
+R4i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.z),intBitsToFloat(R5i.y)) + intBitsToFloat(R3i.x)));
+R4i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.y),intBitsToFloat(R5i.y)) + intBitsToFloat(R3i.y)));
+R4i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.x),intBitsToFloat(R5i.y)) + intBitsToFloat(R3i.z)));
+R2i.w = R126i.z;
+R5i.z = R127i.y;
+PS1i = R5i.z;
+// 8
+R3i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.x),intBitsToFloat(R127i.w)) + 0.5));
+R3i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.y),intBitsToFloat(R125i.z)) + 0.5));
+R3i.z = R126i.y;
+R5i.w = R127i.x;
+R3i.w = R126i.x;
+PS0i = R3i.w;
+// 9
+R0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.x), intBitsToFloat(R126i.w)));
+R0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.y), intBitsToFloat(R124i.z)));
+R0i.z = R124i.w;
+R0i.w = R125i.w;
+// export
+passParameterSem2 = vec4(intBitsToFloat(R4i.x), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w));
+// export
+passParameterSem4 = vec4(intBitsToFloat(R3i.x), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.w));
+// export
+// skipped export to semanticId 255
+// export
+passParameterSem0 = vec4(intBitsToFloat(R5i.x), intBitsToFloat(R5i.y), intBitsToFloat(R5i.z), intBitsToFloat(R5i.w));
+// export
+passParameterSem1 = vec4(intBitsToFloat(R2i.x), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w));
+// export
+passParameterSem6 = vec4(intBitsToFloat(R1i.x), intBitsToFloat(R1i.x), intBitsToFloat(R1i.z), intBitsToFloat(R1i.w));
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/22c410044398c7af_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/22c410044398c7af_0000000000000000_vs.txt
@@ -1,0 +1,103 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader 22c410044398c7af
+// Fixed radius blur
+// shadow pass blur v
+const float resScale = $shadowRes;
+
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 0) out vec4 passParameterSem0;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R2f = vec4(0.0);
+uvec4 attrDecoder;
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = floatBitsToInt(ivec4(gl_VertexID, 0, 0, gl_InstanceID));
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R1f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(floatBitsToInt(1.0)));
+attrDecoder.xy = attrDataSem1.xy;
+attrDecoder.xy = (attrDecoder.xy>>24)|((attrDecoder.xy>>8)&0xFF00)|((attrDecoder.xy<<8)&0xFF0000)|((attrDecoder.xy<<24));
+attrDecoder.z = 0;
+attrDecoder.w = 0;
+R2f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(floatBitsToInt(0.0)), intBitsToFloat(floatBitsToInt(1.0)));
+// 0
+backupReg0f = R1f.x;
+backupReg1f = R1f.y;
+R1f.x = backupReg0f;
+R1f.x *= 2.0;
+R1f.y = backupReg1f;
+R1f.y *= 2.0;
+R1f.z = -(1.0);
+R1f.w = 1.0;
+PS0f = intBitsToFloat(uf_remappedVS[0].y) / resScale * intBitsToFloat(0x3fae8a72);
+// 1
+backupReg0f = R2f.y;
+R0f.x = R2f.x;
+R0f.y = R2f.y;
+R2f.z = R2f.y + PS0f;
+R2f.w = R2f.y;
+R2f.y = backupReg0f + -(PS0f);
+PS1f = R2f.y;
+// export
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
+// export
+passParameterSem0 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
+// export
+// skipped export to semanticId 255
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/2a2f55a2b2d64474_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/2a2f55a2b2d64474_0000000000000000_vs.txt
@@ -1,0 +1,107 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader 2a2f55a2b2d64474
+// Fixed radius blur
+// shadow pass blur h
+const float resScale = $shadowRes;
+
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 0) out vec4 passParameterSem0;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R2f = vec4(0.0);
+vec4 R3f = vec4(0.0);
+vec4 R127f = vec4(0.0);
+uvec4 attrDecoder;
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = floatBitsToInt(ivec4(gl_VertexID, 0, 0, gl_InstanceID));
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R1f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(floatBitsToInt(1.0)));
+attrDecoder.xy = attrDataSem1.xy;
+attrDecoder.xy = (attrDecoder.xy>>24)|((attrDecoder.xy>>8)&0xFF00)|((attrDecoder.xy<<8)&0xFF0000)|((attrDecoder.xy<<24));
+attrDecoder.z = 0;
+attrDecoder.w = 0;
+R2f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(floatBitsToInt(0.0)), intBitsToFloat(floatBitsToInt(1.0)));
+// 0
+backupReg0f = R1f.x;
+backupReg1f = R1f.y;
+R1f.x = backupReg0f;
+R1f.x *= 2.0;
+R1f.y = backupReg1f;
+R1f.y *= 2.0;
+R1f.z = -(1.0);
+R1f.w = 1.0;
+R127f.x = intBitsToFloat(uf_remappedVS[0].x) / resScale * intBitsToFloat(0x3fae8a72);
+PS0f = R127f.x;
+// 1
+R3f.x = R2f.x;
+R3f.y = R2f.y;
+R0f.z = R2f.x + PS0f;
+R0f.w = R2f.x;
+R0f.x = R2f.y;
+PS1f = R0f.x;
+// 2
+R0f.y = R2f.x + -(R127f.x);
+// export
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
+// export
+passParameterSem0 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
+// export
+// skipped export to semanticId 255
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/381d034349896360_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/381d034349896360_0000000000000000_vs.txt
@@ -1,0 +1,132 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader 381d034349896360
+// Used for: Horizontal Volumetric Light Blur
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 0) out vec4 passParameterSem0;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R126f = vec4(0.0);
+vec4 R127f = vec4(0.0);
+uvec4 attrDecoder;
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = floatBitsToInt(ivec4(gl_VertexID, 0, 0, gl_InstanceID));
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R1f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(floatBitsToInt(1.0)));
+// 0
+R127f.x = -(R1f.y);
+PV0f.x = R127f.x;
+R127f.y = (R1f.x > 0.0)?1.0:0.0;
+R127f.y /= 2.0;
+R127f.z = (0.0 > R1f.x)?1.0:0.0;
+R127f.z /= 2.0;
+R127f.w = 1.0;
+PV0f.w = R127f.w;
+// 1
+R0f.x = dot(vec4(R1f.x,R1f.y,R1f.z,PV0f.w),vec4(intBitsToFloat(uf_remappedVS[0].x),intBitsToFloat(uf_remappedVS[0].y),intBitsToFloat(uf_remappedVS[0].z),intBitsToFloat(uf_remappedVS[0].w)));
+PV1f.x = R0f.x;
+PV1f.y = R0f.x;
+PV1f.z = R0f.x;
+PV1f.w = R0f.x;
+R126f.z = (PV0f.x > 0.0)?1.0:0.0;
+R126f.z /= 2.0;
+PS1f = R126f.z;
+// 2
+backupReg0f = R127f.x;
+tempf.x = dot(vec4(R1f.x,R1f.y,R1f.z,R127f.w),vec4(intBitsToFloat(uf_remappedVS[1].x),intBitsToFloat(uf_remappedVS[1].y),intBitsToFloat(uf_remappedVS[1].z),intBitsToFloat(uf_remappedVS[1].w)));
+PV0f.x = tempf.x;
+PV0f.y = tempf.x;
+PV0f.z = tempf.x;
+PV0f.w = tempf.x;
+R0f.y = tempf.x;
+R127f.x = (0.0 > backupReg0f)?1.0:0.0;
+R127f.x /= 2.0;
+PS0f = R127f.x;
+// 3
+tempf.x = dot(vec4(R1f.x,R1f.y,R1f.z,R127f.w),vec4(intBitsToFloat(uf_remappedVS[2].x),intBitsToFloat(uf_remappedVS[2].y),intBitsToFloat(uf_remappedVS[2].z),intBitsToFloat(uf_remappedVS[2].w)));
+PV1f.x = tempf.x;
+PV1f.y = tempf.x;
+PV1f.z = tempf.x;
+PV1f.w = tempf.x;
+R0f.z = tempf.x;
+R126f.w = R127f.y + -(R127f.z);
+PS1f = R126f.w;
+// 4
+tempf.x = dot(vec4(R1f.x,R1f.y,R1f.z,R127f.w),vec4(intBitsToFloat(uf_remappedVS[3].x),intBitsToFloat(uf_remappedVS[3].y),intBitsToFloat(uf_remappedVS[3].z),intBitsToFloat(uf_remappedVS[3].w)));
+PV0f.x = tempf.x;
+PV0f.y = tempf.x;
+PV0f.z = tempf.x;
+PV0f.w = tempf.x;
+R0f.w = tempf.x;
+PS0f = R126f.z + -(R127f.x);
+// 5
+PV1f.x = PS0f + 0.5;
+PV1f.y = R126f.w + 0.5;
+// 6
+R1f.x = PV1f.x;
+R1f.y = (-(intBitsToFloat(uf_remappedVS[4].z)) * 0.5 / resXScale + PV1f.y);
+R1f.z = (intBitsToFloat(uf_remappedVS[4].z) * 0.5 / resXScale + PV1f.y);
+R1f.w = PV1f.y;
+// export
+SET_POSITION(vec4(R0f.x, R0f.y, R0f.z, R0f.w));
+// export
+passParameterSem0 = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/44b73ce02e05c2e6_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/44b73ce02e05c2e6_0000000000000000_vs.txt
@@ -1,0 +1,123 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader 44b73ce02e05c2e6
+// Used for: Vertical Self-Shadowing Mask Fix Blur
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 0) out vec4 passParameterSem0;
+layout(location = 1) out vec4 passParameterSem1;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R2f = vec4(0.0);
+vec4 R3f = vec4(0.0);
+vec4 R126f = vec4(0.0);
+vec4 R127f = vec4(0.0);
+uvec4 attrDecoder;
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = floatBitsToInt(ivec4(gl_VertexID, 0, 0, gl_InstanceID));
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R1f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(floatBitsToInt(1.0)));
+attrDecoder.xy = attrDataSem1.xy;
+attrDecoder.xy = (attrDecoder.xy>>24)|((attrDecoder.xy>>8)&0xFF00)|((attrDecoder.xy<<8)&0xFF0000)|((attrDecoder.xy<<24));
+attrDecoder.z = 0;
+attrDecoder.w = 0;
+R2f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(floatBitsToInt(0.0)), intBitsToFloat(floatBitsToInt(1.0)));
+// 0
+backupReg0f = R1f.x;
+backupReg1f = R1f.y;
+R1f.x = backupReg0f;
+R1f.x *= 2.0;
+R1f.y = backupReg1f;
+R1f.y *= 2.0;
+R1f.z = intBitsToFloat(0xbf5fdfe0);
+R1f.w = 1.0;
+R127f.x = intBitsToFloat(uf_remappedVS[0].y) * intBitsToFloat(0x3fb13a93) / resYScale;
+PS0f = R127f.x;
+// 1
+R126f.x = intBitsToFloat(uf_remappedVS[0].y) * intBitsToFloat(0x404ec4f0) / resYScale;
+PV1f.x = R126f.x;
+R3f.y = R2f.y;
+R3f.z = R2f.x;
+R2f.w = R2f.y;
+PV1f.w = R2f.w;
+R2f.z = R2f.y + PS0f;
+PS1f = R2f.z;
+// 2
+R0f.x = R2f.x;
+R0f.y = R2f.y + -(R127f.x);
+R0f.z = PS1f;
+R0f.w = PV1f.w;
+R2f.z = R2f.y + PV1f.x;
+PS0f = R2f.z;
+// 3
+backupReg0f = R2f.y;
+backupReg0f = R2f.y;
+R2f.y = backupReg0f + -(R126f.x);
+R2f.w = backupReg0f;
+// export
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
+// export
+passParameterSem0 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
+// export
+passParameterSem1 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
+// export
+// skipped export to semanticId 255
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/4721609a424e9a1f_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/4721609a424e9a1f_0000000000000000_vs.txt
@@ -1,0 +1,214 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader 4721609a424e9a1f
+// Used for: Restoring the native BotW Anti-Aliasing implementation
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 1) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+TEXTURE_LAYOUT(32, 0, 0) uniform sampler2D textureUnitVS0;
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 1) out vec4 passParameterSem4;
+layout(location = 0) out vec4 passParameterSem0;
+layout(location = 2) out vec4 passParameterSem6;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+ivec4 R0i = ivec4(0);
+ivec4 R1i = ivec4(0);
+ivec4 R2i = ivec4(0);
+ivec4 R3i = ivec4(0);
+ivec4 R4i = ivec4(0);
+ivec4 R5i = ivec4(0);
+ivec4 R6i = ivec4(0);
+ivec4 R123i = ivec4(0);
+ivec4 R124i = ivec4(0);
+ivec4 R125i = ivec4(0);
+ivec4 R126i = ivec4(0);
+ivec4 R127i = ivec4(0);
+uvec4 attrDecoder;
+int backupReg0i, backupReg1i, backupReg2i, backupReg3i, backupReg4i;
+ivec4 PV0i = ivec4(0), PV1i = ivec4(0);
+int PS0i = 0, PS1i = 0;
+ivec4 tempi = ivec4(0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0i = ivec4(gl_VertexID, 0, 0, gl_InstanceID);
+attrDecoder.xyzw = attrDataSem0.xyzw;
+attrDecoder = ((attrDecoder>>8)&0xFF)|((attrDecoder<<8)&0xFF00);
+attrDecoder.xyzw = floatBitsToInt(vec4(unpackHalf2x16(attrDecoder.x|(attrDecoder.y<<16)),unpackHalf2x16(attrDecoder.z|(attrDecoder.w<<16))));
+R1i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder.x = attrDataSem1.x;
+attrDecoder.x = (attrDecoder.x>>24)|((attrDecoder.x>>8)&0xFF00)|((attrDecoder.x<<8)&0xFF0000)|((attrDecoder.x<<24));
+attrDecoder.y = 0;
+attrDecoder.z = 0;
+attrDecoder.w = 0;
+attrDecoder.xyzw = uvec4((attrDecoder.x>>0)&0x3FF,(attrDecoder.x>>10)&0x3FF,(attrDecoder.x>>20)&0x3FF,(attrDecoder.x>>30)&0x3);
+if( (attrDecoder.x&0x200) != 0 ) attrDecoder.x |= 0xFFFFFC00;
+if( (attrDecoder.y&0x200) != 0 ) attrDecoder.y |= 0xFFFFFC00;
+if( (attrDecoder.z&0x200) != 0 ) attrDecoder.z |= 0xFFFFFC00;
+attrDecoder.x = floatBitsToUint(max(float(int(attrDecoder.x))/511.0,-1.0));
+attrDecoder.y = floatBitsToUint(max(float(int(attrDecoder.y))/511.0,-1.0));
+attrDecoder.z = floatBitsToUint(max(float(int(attrDecoder.z))/511.0,-1.0));
+attrDecoder.w = floatBitsToUint(float(attrDecoder.w));
+R2i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+// 0
+backupReg0i = R0i.x;
+PV0i.x = (backupReg0i == int(1))?int(0xFFFFFFFF):int(0x0);
+R127i.y = 0x3f800000;
+PV0i.z = 0x3f800000;
+PV0i.w = 0x40400000;
+R127i.z = 0xbf800000;
+PS0i = R127i.z;
+// 1
+PV1i.x = floatBitsToInt(intBitsToFloat(uf_remappedVS[0].z) * intBitsToFloat(0x3b808081));
+R123i.y = ((PV0i.x == 0)?(PV0i.w):(0xbf800000));
+PV1i.y = R123i.y;
+R0i.z = 0;
+R123i.w = ((PV0i.x == 0)?(PV0i.z):(0xc0400000));
+PV1i.w = R123i.w;
+R1i.w = 0x3f800000;
+PS1i = R1i.w;
+// 2
+R1i.x = ((R0i.x == 0)?(R127i.z):(PV1i.y));
+PV0i.x = R1i.x;
+R1i.y = ((R0i.x == 0)?(R127i.y):(PV1i.w));
+PV0i.y = R1i.y;
+R1i.z = floatBitsToInt(intBitsToFloat(PV1i.x) + -(0.5));
+R1i.z = floatBitsToInt(intBitsToFloat(R1i.z) * 2.0);
+R0i.w = 0x3d2aaaab;
+R0i.x = 0x3e000000;
+PS0i = R0i.x;
+// 3
+R5i.x = floatBitsToInt((intBitsToFloat(PV0i.x) * 0.5 + 0.5));
+PV1i.x = R5i.x;
+R0i.y = 0;
+PV1i.z = floatBitsToInt(-(intBitsToFloat(PV0i.y)));
+R4i.w = uf_remappedVS[1].z;
+R4i.w = floatBitsToInt(intBitsToFloat(R4i.w) / 2.0);
+PV1i.w = R4i.w;
+R4i.x = floatBitsToInt(-(intBitsToFloat(uf_remappedVS[2].z)));
+R4i.x = floatBitsToInt(intBitsToFloat(R4i.x) / 2.0);
+PS1i = R4i.x;
+// 4
+R3i.x = floatBitsToInt(-(intBitsToFloat(R1i.y)));
+R3i.x = floatBitsToInt(intBitsToFloat(R3i.x) / 2.0);
+R5i.y = floatBitsToInt((intBitsToFloat(PV1i.z) * 0.5 + 0.5));
+R6i.z = PV1i.x;
+R3i.w = R1i.x;
+R3i.w = floatBitsToInt(intBitsToFloat(R3i.w) / 2.0);
+R3i.y = floatBitsToInt(intBitsToFloat(PV1i.w) + -(0.5));
+PS0i = R3i.y;
+R2i.w = floatBitsToInt(texture(textureUnitVS0, intBitsToFloat(R0i.wz)).x);
+R2i.xyz = floatBitsToInt(texture(textureUnitVS0, intBitsToFloat(R0i.xy)).xyz);
+// export
+SET_POSITION(vec4(intBitsToFloat(R1i.x), intBitsToFloat(R1i.y), intBitsToFloat(R1i.z), intBitsToFloat(R1i.w)));
+// export
+// skipped export to semanticId 255
+// 0
+R127i.x = floatBitsToInt(intBitsToFloat(R4i.x) + -(0.5));
+R2i.y = floatBitsToInt(-(intBitsToFloat(uf_remappedVS[3].x)));
+R2i.y = floatBitsToInt(intBitsToFloat(R2i.y) * 2.0);
+PV0i.y = R2i.y;
+R127i.z = uf_remappedVS[3].y;
+R127i.z = floatBitsToInt(intBitsToFloat(R127i.z) * 2.0);
+R6i.w = R5i.y;
+PV0i.w = R6i.w;
+PS0i = floatBitsToInt(intBitsToFloat(R3i.w) + intBitsToFloat(R4i.w));
+// 1
+PV1i.x = floatBitsToInt(intBitsToFloat(R3i.x) + intBitsToFloat(R4i.x));
+R126i.y = floatBitsToInt(intBitsToFloat(R5i.x) + intBitsToFloat(R3i.y));
+PV1i.z = floatBitsToInt(intBitsToFloat(PV0i.w) + intBitsToFloat(uf_remappedVS[4].w)/resYScale);
+R127i.w = floatBitsToInt(intBitsToFloat(R6i.z) + intBitsToFloat(uf_remappedVS[4].z)/resXScale);
+R127i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.y), intBitsToFloat(PS0i)));
+PS1i = R127i.y;
+// 2
+PV0i.x = floatBitsToInt(intBitsToFloat(PV1i.z) + intBitsToFloat(R127i.x));
+R125i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.z), intBitsToFloat(PV1i.x)));
+R126i.z = floatBitsToInt(intBitsToFloat(uf_remappedVS[4].y)*resYScale);
+R126i.z = floatBitsToInt(intBitsToFloat(R126i.z) / 2.0);
+R126i.w = floatBitsToInt(intBitsToFloat(uf_remappedVS[4].x)*resXScale);
+R126i.w = floatBitsToInt(intBitsToFloat(R126i.w) / 2.0);
+R124i.y = floatBitsToInt(intBitsToFloat(uf_remappedVS[4].z)/resXScale);
+R124i.y = floatBitsToInt(intBitsToFloat(R124i.y) * 2.0);
+PS0i = R124i.y;
+// 3
+backupReg0i = R127i.x;
+backupReg1i = R127i.w;
+backupReg2i = R127i.y;
+R127i.x = floatBitsToInt(intBitsToFloat(uf_remappedVS[4].w)/resYScale);
+R127i.x = floatBitsToInt(intBitsToFloat(R127i.x) * 2.0);
+R127i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.z), intBitsToFloat(PV0i.x)));
+PV1i.z = floatBitsToInt(intBitsToFloat(R5i.y) + intBitsToFloat(backupReg0i));
+R127i.w = floatBitsToInt(intBitsToFloat(backupReg1i) + intBitsToFloat(R3i.y));
+R5i.z = backupReg2i;
+PS1i = R5i.z;
+// 4
+R3i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.x),intBitsToFloat(R126i.w)) + 0.5));
+R4i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.z), intBitsToFloat(PV1i.z)));
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.y), intBitsToFloat(R126i.y)));
+R5i.w = R125i.y;
+PS0i = R5i.w;
+// 5
+R4i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.y), intBitsToFloat(R127i.w)));
+R3i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.y),intBitsToFloat(R126i.z)) + 0.5));
+R3i.z = R124i.y;
+R3i.w = R127i.x;
+R4i.z = PV0i.w;
+PS1i = R4i.z;
+// 6
+R4i.w = R127i.y;
+// export
+passParameterSem4 = vec4(intBitsToFloat(R3i.x), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.w));
+// export
+// skipped export to semanticId 255
+// export
+passParameterSem0 = vec4(intBitsToFloat(R5i.x), intBitsToFloat(R5i.y), intBitsToFloat(R5i.z), intBitsToFloat(R5i.w));
+// export
+passParameterSem6 = vec4(intBitsToFloat(R6i.x), intBitsToFloat(R6i.x), intBitsToFloat(R6i.z), intBitsToFloat(R6i.w));
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/5c1761d13feccdff_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/5c1761d13feccdff_0000000000000000_vs.txt
@@ -1,0 +1,103 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader 5c1761d13feccdff
+// Used for: Vertical+Horizontal Fullscreen Blur
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 0) out vec4 passParameterSem3;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R2f = vec4(0.0);
+uvec4 attrDecoder;
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = floatBitsToInt(ivec4(gl_VertexID, 0, 0, gl_InstanceID));
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R1f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(floatBitsToInt(1.0)));
+attrDecoder.xy = attrDataSem1.xy;
+attrDecoder.xy = (attrDecoder.xy>>24)|((attrDecoder.xy>>8)&0xFF00)|((attrDecoder.xy<<8)&0xFF0000)|((attrDecoder.xy<<24));
+attrDecoder.z = 0;
+attrDecoder.w = 0;
+R2f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(floatBitsToInt(0.0)), intBitsToFloat(floatBitsToInt(1.0)));
+// 0
+backupReg0f = R1f.x;
+backupReg1f = R1f.y;
+R1f.x = backupReg0f;
+R1f.x *= 2.0;
+R1f.y = backupReg1f;
+R1f.y *= 2.0;
+R1f.z = intBitsToFloat(0xbf800000);
+R1f.w = 1.0;
+PS0f = R2f.x + -(intBitsToFloat(uf_remappedVS[0].x)/resXScale);
+// 1
+backupReg0f = R2f.y;
+backupReg1f = R2f.x;
+PV1f.x = R2f.y + -(intBitsToFloat(uf_remappedVS[0].y)/resYScale);
+R2f.y = backupReg0f + intBitsToFloat(uf_remappedVS[0].y)/resYScale;
+R2f.z = PS0f;
+R2f.x = backupReg1f + intBitsToFloat(uf_remappedVS[0].x)/resXScale;
+PS1f = R2f.x;
+// 2
+R2f.w = PV1f.x;
+// export
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
+// export
+passParameterSem3 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/5c975b0e3dac0562_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/5c975b0e3dac0562_0000000000000000_vs.txt
@@ -1,0 +1,111 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader 5c975b0e3dac0562
+// Used for: Horizontal Bloom Blur
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 1) out vec4 passParameterSem1;
+layout(location = 0) out vec4 passParameterSem0;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R2f = vec4(0.0);
+uvec4 attrDecoder;
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = floatBitsToInt(ivec4(gl_VertexID, 0, 0, gl_InstanceID));
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R1f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(floatBitsToInt(1.0)));
+attrDecoder.xy = attrDataSem1.xy;
+attrDecoder.xy = (attrDecoder.xy>>24)|((attrDecoder.xy>>8)&0xFF00)|((attrDecoder.xy<<8)&0xFF0000)|((attrDecoder.xy<<24));
+attrDecoder.z = 0;
+attrDecoder.w = 0;
+R2f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(floatBitsToInt(0.0)), intBitsToFloat(floatBitsToInt(1.0)));
+// 0
+backupReg0f = R1f.x;
+backupReg1f = R1f.y;
+R1f.x = backupReg0f;
+R1f.x *= 2.0;
+R1f.y = backupReg1f;
+R1f.y *= 2.0;
+R1f.z = 0.0;
+R1f.w = 1.0;
+PS0f = intBitsToFloat(uf_remappedVS[0].x) / resXScale * intBitsToFloat(0x3fb13a93);
+// 1
+PV1f.x = intBitsToFloat(uf_remappedVS[0].x) / resXScale * intBitsToFloat(0x404ec4f0);
+R0f.y = R2f.x + -(PS0f);
+R0f.z = R2f.x + PS0f;
+R0f.w = R2f.x;
+R0f.x = R2f.y;
+PS1f = R0f.x;
+// 2
+backupReg0f = R2f.x;
+backupReg0f = R2f.x;
+backupReg0f = R2f.x;
+R2f.x = PS1f;
+R2f.y = backupReg0f + -(PV1f.x);
+R2f.z = backupReg0f + PV1f.x;
+R2f.w = backupReg0f;
+// export
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
+// export
+passParameterSem1 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
+// export
+passParameterSem0 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/75a85b0cbcab764b_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/75a85b0cbcab764b_0000000000000000_vs.txt
@@ -1,0 +1,111 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader 75a85b0cbcab764b
+// Used for: Horizontal Reflection Blur
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 1) out vec4 passParameterSem1;
+layout(location = 0) out vec4 passParameterSem0;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R2f = vec4(0.0);
+uvec4 attrDecoder;
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = floatBitsToInt(ivec4(gl_VertexID, 0, 0, gl_InstanceID));
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R1f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(floatBitsToInt(1.0)));
+attrDecoder.xy = attrDataSem1.xy;
+attrDecoder.xy = (attrDecoder.xy>>24)|((attrDecoder.xy>>8)&0xFF00)|((attrDecoder.xy<<8)&0xFF0000)|((attrDecoder.xy<<24));
+attrDecoder.z = 0;
+attrDecoder.w = 0;
+R2f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(floatBitsToInt(0.0)), intBitsToFloat(floatBitsToInt(1.0)));
+// 0
+backupReg0f = R1f.x;
+backupReg1f = R1f.y;
+R1f.x = backupReg0f;
+R1f.x *= 2.0;
+R1f.y = backupReg1f;
+R1f.y *= 2.0;
+R1f.z = 0.0;
+R1f.w = 1.0;
+PS0f = intBitsToFloat(uf_remappedVS[0].x) / resXScale * intBitsToFloat(0x3fb13a93);
+// 1
+PV1f.x = intBitsToFloat(uf_remappedVS[0].x) / resXScale * intBitsToFloat(0x404ec4f0);
+R0f.y = R2f.x + -(PS0f);
+R0f.z = R2f.x + PS0f;
+R0f.w = R2f.x;
+R0f.x = R2f.y;
+PS1f = R0f.x;
+// 2
+backupReg0f = R2f.x;
+backupReg0f = R2f.x;
+backupReg0f = R2f.x;
+R2f.x = PS1f;
+R2f.y = backupReg0f + -(PV1f.x);
+R2f.z = backupReg0f + PV1f.x;
+R2f.w = backupReg0f;
+// export
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
+// export
+passParameterSem1 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
+// export
+passParameterSem0 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/771e24915acbb074_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/771e24915acbb074_0000000000000000_vs.txt
@@ -1,0 +1,117 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader 771e24915acbb074
+// Used for: Vertical Reflection Blur
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 0) out vec4 passParameterSem0;
+layout(location = 1) out vec4 passParameterSem1;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R2f = vec4(0.0);
+vec4 R127f = vec4(0.0);
+uvec4 attrDecoder;
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = floatBitsToInt(ivec4(gl_VertexID, 0, 0, gl_InstanceID));
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R1f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(floatBitsToInt(1.0)));
+attrDecoder.xy = attrDataSem1.xy;
+attrDecoder.xy = (attrDecoder.xy>>24)|((attrDecoder.xy>>8)&0xFF00)|((attrDecoder.xy<<8)&0xFF0000)|((attrDecoder.xy<<24));
+attrDecoder.z = 0;
+attrDecoder.w = 0;
+R2f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(floatBitsToInt(0.0)), intBitsToFloat(floatBitsToInt(1.0)));
+// 0
+backupReg0f = R1f.x;
+backupReg1f = R1f.y;
+R1f.x = backupReg0f;
+R1f.x *= 2.0;
+R1f.y = backupReg1f;
+R1f.y *= 2.0;
+R1f.z = 0.0;
+R1f.w = 1.0;
+PS0f = intBitsToFloat(uf_remappedVS[0].y) / resYScale * intBitsToFloat(0x3fb13a93);
+// 1
+R127f.x = intBitsToFloat(uf_remappedVS[0].y) / resYScale * intBitsToFloat(0x404ec4f0);
+PV1f.x = R127f.x;
+R0f.y = R2f.y + -(PS0f);
+R2f.z = R2f.y + PS0f;
+PV1f.z = R2f.z;
+R2f.w = R2f.y;
+PV1f.w = R2f.w;
+R0f.x = R2f.x;
+PS1f = R0f.x;
+// 2
+R0f.z = PV1f.z;
+R0f.w = PV1f.w;
+R2f.z = R2f.y + PV1f.x;
+PS0f = R2f.z;
+// 3
+backupReg0f = R2f.y;
+backupReg0f = R2f.y;
+R2f.y = backupReg0f + -(R127f.x);
+R2f.w = backupReg0f;
+// export
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
+// export
+passParameterSem0 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
+// export
+passParameterSem1 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/7cd338ce4c6ea935_0000000000000079_ps.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/7cd338ce4c6ea935_0000000000000079_ps.txt
@@ -1,0 +1,104 @@
+#version 430
+#extension GL_ARB_texture_gather : enable
+#extension GL_ARB_separate_shader_objects : enable
+// shader 7cd338ce4c6ea935
+// Used for: Ultrawide cutscenes (when enabled)
+float aspectRatio = float(($gameWidth/$gameHeight)/($width/$height));
+float reverseAspectRatio = float(($width/$height)/($gameWidth/$gameHeight));
+
+
+// start of shader inputs/outputs, predetermined by Cemu. Do not touch
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
+uniform ivec4 uf_remappedPS[1];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[1];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+layout(location = 0) in vec4 passParameterSem0;
+layout(location = 0) out vec4 passPixelColor0;
+// end of shader inputs/outputs
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R127f = vec4(0.0);
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = passParameterSem0;
+
+#if $ultrawideHUDMode != 0
+float uv_x = 0.5 + (R0f.x - 0.5) / aspectRatio;
+R0f.xyzw = (texture(textureUnitPS0, vec2(uv_x, R0f.y)).xyzw);
+#else
+R0f.xyzw = (texture(textureUnitPS0, vec2(R0f.xy)).xyzw);
+#endif
+// 0
+backupReg0f = R0f.x;
+tempResultf = max(0.0, backupReg0f);
+tempResultf = log2(tempResultf);
+if( isinf(tempResultf) == true ) tempResultf = -3.40282347E+38F;
+PS0f = tempResultf;
+// 1
+R127f.z = mul_nonIEEE(PS0f, intBitsToFloat(uf_remappedPS[0].x));
+tempResultf = max(0.0, R0f.y);
+tempResultf = log2(tempResultf);
+if( isinf(tempResultf) == true ) tempResultf = -3.40282347E+38F;
+PS1f = tempResultf;
+// 2
+R127f.w = mul_nonIEEE(PS1f, intBitsToFloat(uf_remappedPS[0].x));
+tempResultf = max(0.0, R0f.z);
+tempResultf = log2(tempResultf);
+if( isinf(tempResultf) == true ) tempResultf = -3.40282347E+38F;
+PS0f = tempResultf;
+// 3
+R127f.x = mul_nonIEEE(PS0f, intBitsToFloat(uf_remappedPS[0].x));
+PS1f = exp2(R127f.z);
+// 4
+R0f.x = PS1f;
+PS0f = exp2(R127f.w);
+// 5
+R0f.y = PS0f;
+PS1f = exp2(R127f.x);
+// 6
+R0f.z = PS1f;
+// export
+
+#if $ultrawideHUDMode != 0
+bool isBorder = uv_x < 0 || uv_x > 1.0;
+passPixelColor0 = isBorder ? vec4(0.0) : R0f.xyzw;
+#else
+passPixelColor0 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
+#endif
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/81eb264a750163d9_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/81eb264a750163d9_0000000000000000_vs.txt
@@ -1,0 +1,132 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader 81eb264a750163d9
+// Used for: Vertical Volumetric Light Blur
+// volumetric light blur v
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 0) out vec4 passParameterSem0;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R126f = vec4(0.0);
+vec4 R127f = vec4(0.0);
+uvec4 attrDecoder;
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = floatBitsToInt(ivec4(gl_VertexID, 0, 0, gl_InstanceID));
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R1f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(floatBitsToInt(1.0)));
+// 0
+R127f.x = -(R1f.y);
+PV0f.x = R127f.x;
+R126f.y = (0.0 > R1f.x)?1.0:0.0;
+R126f.y /= 2.0;
+R127f.z = (R1f.x > 0.0)?1.0:0.0;
+R127f.z /= 2.0;
+R127f.w = 1.0;
+PV0f.w = R127f.w;
+// 1
+R0f.x = dot(vec4(R1f.x,R1f.y,R1f.z,PV0f.w),vec4(intBitsToFloat(uf_remappedVS[0].x),intBitsToFloat(uf_remappedVS[0].y),intBitsToFloat(uf_remappedVS[0].z),intBitsToFloat(uf_remappedVS[0].w)));
+PV1f.x = R0f.x;
+PV1f.y = R0f.x;
+PV1f.z = R0f.x;
+PV1f.w = R0f.x;
+R127f.y = (PV0f.x > 0.0)?1.0:0.0;
+R127f.y /= 2.0;
+PS1f = R127f.y;
+// 2
+tempf.x = dot(vec4(R1f.x,R1f.y,R1f.z,R127f.w),vec4(intBitsToFloat(uf_remappedVS[1].x),intBitsToFloat(uf_remappedVS[1].y),intBitsToFloat(uf_remappedVS[1].z),intBitsToFloat(uf_remappedVS[1].w)));
+PV0f.x = tempf.x;
+PV0f.y = tempf.x;
+PV0f.z = tempf.x;
+PV0f.w = tempf.x;
+R0f.y = tempf.x;
+PS0f = (0.0 > R127f.x)?1.0:0.0;
+PS0f /= 2.0;
+// 3
+backupReg0f = R127f.y;
+tempf.x = dot(vec4(R1f.x,R1f.y,R1f.z,R127f.w),vec4(intBitsToFloat(uf_remappedVS[2].x),intBitsToFloat(uf_remappedVS[2].y),intBitsToFloat(uf_remappedVS[2].z),intBitsToFloat(uf_remappedVS[2].w)));
+PV1f.x = tempf.x;
+PV1f.y = tempf.x;
+PV1f.z = tempf.x;
+PV1f.w = tempf.x;
+R0f.z = tempf.x;
+R127f.y = backupReg0f + -(PS0f);
+PS1f = R127f.y;
+// 4
+tempf.x = dot(vec4(R1f.x,R1f.y,R1f.z,R127f.w),vec4(intBitsToFloat(uf_remappedVS[3].x),intBitsToFloat(uf_remappedVS[3].y),intBitsToFloat(uf_remappedVS[3].z),intBitsToFloat(uf_remappedVS[3].w)));
+PV0f.x = tempf.x;
+PV0f.y = tempf.x;
+PV0f.z = tempf.x;
+PV0f.w = tempf.x;
+R0f.w = tempf.x;
+PS0f = R127f.z + -(R126f.y);
+// 5
+PV1f.x = R127f.y + 0.5;
+R1f.x = PS0f + 0.5;
+PS1f = R1f.x;
+// 6
+R1f.y = (-(intBitsToFloat(uf_remappedVS[4].w)) * 0.5 / resYScale + PV1f.x);
+R1f.z = (intBitsToFloat(uf_remappedVS[4].w) * 0.5 / resYScale + PV1f.x);
+R1f.w = PV1f.x;
+// export
+SET_POSITION(vec4(R0f.x, R0f.y, R0f.z, R0f.w));
+// export
+passParameterSem0 = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/88133ee405eaae28_000003c000009269_ps.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/88133ee405eaae28_000003c000009269_ps.txt
@@ -1,0 +1,739 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader 88133ee405eaae28
+// Shadow 2x2 box blur fix
+// shader dumped from BotW v1.4.0, using Cemu 1.11.1
+const float resScale = $shadowRes;
+
+UNIFORM_BUFFER_LAYOUT(33, 1, 7) uniform uniformBlockPS1
+{
+vec4 uf_blockPS1[1024];
+};
+
+UNIFORM_BUFFER_LAYOUT(38, 1, 8) uniform uniformBlockPS6
+{
+vec4 uf_blockPS6[1024];
+};
+
+UNIFORM_BUFFER_LAYOUT(42, 1, 9) uniform uniformBlockPS10
+{
+vec4 uf_blockPS10[1024];
+};
+
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
+TEXTURE_LAYOUT(3, 1, 2) uniform sampler2D textureUnitPS3;
+TEXTURE_LAYOUT(6, 1, 3) uniform sampler2D textureUnitPS6;
+TEXTURE_LAYOUT(8, 1, 4) uniform sampler2DArrayShadow textureUnitPS8;
+TEXTURE_LAYOUT(15, 1, 5) uniform sampler2D textureUnitPS15;
+layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem5;
+layout(location = 2) in vec4 passParameterSem6;
+layout(location = 5) out vec4 passPixelColor5;
+#ifdef VULKAN
+layout(set = 1, binding = 6) uniform ufBlock
+{
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform vec2 uf_fragCoordScale;
+#endif
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+ivec4 R0i = ivec4(0);
+ivec4 R1i = ivec4(0);
+ivec4 R2i = ivec4(0);
+ivec4 R3i = ivec4(0);
+ivec4 R4i = ivec4(0);
+ivec4 R5i = ivec4(0);
+ivec4 R6i = ivec4(0);
+ivec4 R7i = ivec4(0);
+ivec4 R8i = ivec4(0);
+ivec4 R9i = ivec4(0);
+ivec4 R10i = ivec4(0);
+ivec4 R11i = ivec4(0);
+ivec4 R12i = ivec4(0);
+ivec4 R13i = ivec4(0);
+ivec4 R14i = ivec4(0);
+ivec4 R15i = ivec4(0);
+ivec4 R16i = ivec4(0);
+ivec4 R17i = ivec4(0);
+ivec4 R122i = ivec4(0);
+ivec4 R123i = ivec4(0);
+ivec4 R124i = ivec4(0);
+ivec4 R125i = ivec4(0);
+ivec4 R126i = ivec4(0);
+ivec4 R127i = ivec4(0);
+int backupReg0i, backupReg1i, backupReg2i, backupReg3i, backupReg4i;
+ivec4 PV0i = ivec4(0), PV1i = ivec4(0);
+int PS0i = 0, PS1i = 0;
+ivec4 tempi = ivec4(0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+bool activeMaskStack[3];
+bool activeMaskStackC[4];
+activeMaskStack[0] = false;
+activeMaskStack[1] = false;
+activeMaskStackC[0] = false;
+activeMaskStackC[1] = false;
+activeMaskStackC[2] = false;
+activeMaskStack[0] = true;
+activeMaskStackC[0] = true;
+activeMaskStackC[1] = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0i = floatBitsToInt(passParameterSem0);
+R1i = floatBitsToInt(passParameterSem5);
+R2i = floatBitsToInt(passParameterSem6);
+if( activeMaskStackC[1] == true ) {
+R3i.w = floatBitsToInt(texture(textureUnitPS6, intBitsToFloat(R0i.xy)).x);
+R7i.xzw = floatBitsToInt(textureGather(textureUnitPS6, vec2(0.0001) + intBitsToFloat(R0i.xy)).xzw);
+R4i.xyzw = floatBitsToInt(texture(textureUnitPS3, intBitsToFloat(R2i.zw)).xyzw);
+R2i.xy = floatBitsToInt(textureLod(textureUnitPS0, intBitsToFloat(R2i.xy),0.0).xw);
+}
+if( activeMaskStackC[1] == true ) {
+// 0
+R123i.x = floatBitsToInt((mul_nonIEEE(uf_blockPS1[16].x,intBitsToFloat(R7i.w)) + uf_blockPS1[14].x));
+PV0i.x = R123i.x;
+R127i.y = floatBitsToInt((mul_nonIEEE(uf_blockPS1[16].x,intBitsToFloat(R7i.z)) + uf_blockPS1[14].x));
+R127i.z = floatBitsToInt((mul_nonIEEE(uf_blockPS1[16].x,intBitsToFloat(R7i.x)) + uf_blockPS1[14].x));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R3i.w),uf_blockPS1[16].x) + uf_blockPS1[14].x));
+PV0i.w = R123i.w;
+R127i.x = floatBitsToInt((intBitsToFloat(R4i.x) * 2.0 + -(1.0)));
+PS0i = R127i.x;
+// 1
+R3i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R0i.z), -(intBitsToFloat(PV0i.w))));
+R8i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R0i.w), -(intBitsToFloat(PV0i.w))));
+R12i.z = floatBitsToInt(-(intBitsToFloat(PV0i.x)));
+R127i.w = floatBitsToInt((intBitsToFloat(R4i.y) * 2.0 + -(1.0)));
+R125i.z = floatBitsToInt((intBitsToFloat(R4i.z) * 2.0 + -(1.0)));
+PS1i = R125i.z;
+// 2
+PV0i.x = floatBitsToInt(-(intBitsToFloat(R127i.y)));
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.y), -(intBitsToFloat(R127i.y))));
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.x), -(intBitsToFloat(R127i.y))));
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.z), -(intBitsToFloat(R127i.z))));
+R126i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.w), -(intBitsToFloat(R127i.z))));
+PS0i = R126i.z;
+// 3
+R125i.x = floatBitsToInt(-(intBitsToFloat(R3i.x)) + intBitsToFloat(PV0i.z));
+R127i.y = floatBitsToInt(-(intBitsToFloat(R127i.z)));
+R124i.z = floatBitsToInt(-(intBitsToFloat(R12i.z)) + intBitsToFloat(PV0i.x));
+R125i.w = floatBitsToInt(-(intBitsToFloat(R8i.y)) + intBitsToFloat(PV0i.y));
+R126i.y = floatBitsToInt(-(intBitsToFloat(R3i.x)) + intBitsToFloat(PV0i.w));
+PS1i = R126i.y;
+// 4
+backupReg0i = R126i.z;
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R3i.x),intBitsToFloat(R8i.y),intBitsToFloat(R12i.z),-0.0),vec4(intBitsToFloat(R3i.x),intBitsToFloat(R8i.y),intBitsToFloat(R12i.z),0.0)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+R126i.z = tempi.x;
+R126i.x = floatBitsToInt(-(intBitsToFloat(R8i.y)) + intBitsToFloat(backupReg0i));
+PS0i = R126i.x;
+// 5
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R127i.x),intBitsToFloat(R127i.w),intBitsToFloat(R125i.z),-0.0),vec4(intBitsToFloat(R127i.x),intBitsToFloat(R127i.w),intBitsToFloat(R125i.z),0.0)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R127i.z = tempi.x;
+R126i.w = floatBitsToInt(-(intBitsToFloat(R12i.z)) + intBitsToFloat(R127i.y));
+PS1i = R126i.w;
+// 6
+backupReg0i = R126i.z;
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.x), uf_blockPS6[43].x));
+R127i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.z), intBitsToFloat(R126i.y)));
+R126i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.w), intBitsToFloat(PS1i)));
+R124i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.x), intBitsToFloat(R126i.x)));
+R125i.y = floatBitsToInt(sqrt(intBitsToFloat(backupReg0i)));
+PS0i = R125i.y;
+// 7
+backupReg0i = R127i.z;
+R124i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.x), uf_blockPS6[45].x));
+R124i.y = floatBitsToInt(intBitsToFloat(R4i.w) * intBitsToFloat(0x437f0000));
+R127i.z = floatBitsToInt((intBitsToFloat(R2i.x) * 2.0 + -(1.0)));
+R4i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R8i.y),uf_blockPS6[43].y) + intBitsToFloat(PV0i.x)));
+tempResultf = 1.0 / sqrt(intBitsToFloat(backupReg0i));
+PS1i = floatBitsToInt(tempResultf);
+// 8
+backupReg0i = R125i.z;
+R4i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(PS1i)));
+R4i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.w), intBitsToFloat(PS1i)));
+R125i.z = floatBitsToInt(mul_nonIEEE(uf_blockPS1[18].y, uf_blockPS1[18].z));
+PV0i.z = R125i.z;
+R127i.w = floatBitsToInt(-(intBitsToFloat(R12i.z)) * intBitsToFloat(0x3d4ccccd));
+R2i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), intBitsToFloat(PS1i)));
+PS0i = R2i.z;
+// 9
+R1i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R126i.x)),intBitsToFloat(R124i.z)) + intBitsToFloat(R126i.z)));
+R3i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R126i.w)),intBitsToFloat(R125i.x)) + intBitsToFloat(R127i.y)));
+R126i.z = floatBitsToInt((intBitsToFloat(R2i.y) * 2.0 + -(1.0)));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R8i.y),uf_blockPS6[45].y) + intBitsToFloat(R124i.x)));
+PV1i.w = R123i.w;
+R126i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.z), intBitsToFloat(R127i.z)));
+PS1i = R126i.w;
+// 10
+backupReg0i = R126i.y;
+R126i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.z),uf_blockPS6[45].z) + intBitsToFloat(PV1i.w)));
+R126i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.z),uf_blockPS6[43].z) + intBitsToFloat(R4i.w)));
+R1i.z = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(backupReg0i)),intBitsToFloat(R125i.w)) + intBitsToFloat(R124i.w)));
+PV0i.z = R1i.z;
+R125i.w = R4i.x;
+R125i.w = floatBitsToInt(intBitsToFloat(R125i.w) * 2.0);
+R124i.z = R4i.y;
+R124i.z = floatBitsToInt(intBitsToFloat(R124i.z) * 2.0);
+PS0i = R124i.z;
+// 11
+R124i.x = floatBitsToInt(dot(vec4(-(intBitsToFloat(R1i.x)),-(intBitsToFloat(R3i.y)),-(intBitsToFloat(PV0i.z)),-0.0),vec4(-(intBitsToFloat(R1i.x)),-(intBitsToFloat(R3i.y)),-(intBitsToFloat(PV0i.z)),0.0)));
+PV1i.x = R124i.x;
+PV1i.y = R124i.x;
+PV1i.z = R124i.x;
+PV1i.w = R124i.x;
+R2i.x = floatBitsToInt((-(uf_blockPS6[53].w) * intBitsToFloat(0x3d4ccccd) + intBitsToFloat(R127i.w)));
+R2i.x = clampFI32(R2i.x);
+PS1i = R2i.x;
+// 12
+R125i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.z), -(intBitsToFloat(R126i.z))));
+PV0i.x = R125i.x;
+R127i.y = floatBitsToInt(intBitsToFloat(R126i.z) * intBitsToFloat(0xbb6fe5d7));
+PV0i.z = floatBitsToInt(intBitsToFloat(R126i.w) * intBitsToFloat(0x3ca30589));
+PV0i.w = floatBitsToInt(intBitsToFloat(R126i.z) * intBitsToFloat(0x3ca30589));
+R126i.z = floatBitsToInt(intBitsToFloat(R126i.w) * intBitsToFloat(0xbb6fe5d7));
+PS0i = R126i.z;
+// 13
+R7i.x = floatBitsToInt(uf_blockPS6[43].w + intBitsToFloat(R126i.y));
+R1i.y = floatBitsToInt((intBitsToFloat(R127i.z) * intBitsToFloat(0x3b02da3b) + intBitsToFloat(PV0i.w)));
+R3i.z = floatBitsToInt(mul_nonIEEE(-(intBitsToFloat(R12i.z)), uf_blockPS1[17].y));
+R1i.w = 0x3f800000;
+R6i.x = floatBitsToInt((intBitsToFloat(PV0i.x) * intBitsToFloat(0x3b02da3b) + intBitsToFloat(PV0i.z)));
+PS1i = R6i.x;
+// 14
+R5i.x = floatBitsToInt((intBitsToFloat(R125i.x) * intBitsToFloat(0x3d156fb9) + intBitsToFloat(R126i.z)));
+R5i.y = floatBitsToInt((intBitsToFloat(R127i.z) * intBitsToFloat(0x3d156fb9) + intBitsToFloat(R127i.y)));
+R13i.z = floatBitsToInt(uf_blockPS6[45].w + intBitsToFloat(R126i.x));
+R12i.w = floatBitsToInt((-(uf_blockPS6[53].z) * intBitsToFloat(0x3d4ccccd) + intBitsToFloat(R127i.w)));
+R12i.w = clampFI32(R12i.w);
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(R125i.y));
+// 15
+backupReg0i = R124i.y;
+R126i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.x), intBitsToFloat(PS0i)));
+PV1i.x = R126i.x;
+R124i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R8i.y), intBitsToFloat(PS0i)));
+PV1i.y = R124i.y;
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R12i.z), intBitsToFloat(PS0i)));
+PS1i = int(intBitsToFloat(backupReg0i));
+// 16
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R4i.x),intBitsToFloat(R4i.y),intBitsToFloat(R2i.z),-0.0),vec4(intBitsToFloat(PV1i.x),intBitsToFloat(PV1i.y),intBitsToFloat(PV1i.z),0.0)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+PS0i = PS1i & int(1);
+// 17
+R12i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(PV0i.x)),intBitsToFloat(R125i.w)) + intBitsToFloat(R126i.x)));
+R7i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(PV0i.x)),intBitsToFloat(R124i.z)) + intBitsToFloat(R124i.y)));
+R13i.w = floatBitsToInt(intBitsToFloat(PV0i.x) + 1.0);
+R13i.w = clampFI32(R13i.w);
+R2i.y = ((PS0i == 0)?(0):(0x3f800000));
+PS1i = R2i.y;
+// 18
+tempResultf = 1.0 / sqrt(intBitsToFloat(R124i.x));
+R2i.w = floatBitsToInt(tempResultf);
+PS0i = R2i.w;
+}
+if( activeMaskStackC[1] == true ) {
+activeMaskStack[1] = activeMaskStack[0];
+activeMaskStackC[2] = activeMaskStackC[1];
+// 0
+PV0i.x = floatBitsToInt(uf_blockPS10[2].z + 1.0);
+R9i.y = floatBitsToInt(mul_nonIEEE(uf_blockPS6[4].y, uf_blockPS10[2].w));
+R8i.x = floatBitsToInt(mul_nonIEEE(uf_blockPS6[4].x, uf_blockPS10[2].w));
+PS0i = R8i.x;
+// 1
+R10i.z = floatBitsToInt(mul_nonIEEE(uf_blockPS6[4].z, uf_blockPS10[2].w));
+R14i.w = floatBitsToInt(-(intBitsToFloat(R2i.x)) + intBitsToFloat(PV0i.x));
+R14i.w = clampFI32(R14i.w);
+R4i.w = 0;
+PS1i = R4i.w;
+// 2
+predResult = (1.0 > intBitsToFloat(R12i.w));
+activeMaskStack[1] = predResult;
+activeMaskStackC[2] = predResult == true && activeMaskStackC[1] == true;
+}
+else {
+activeMaskStack[1] = false;
+activeMaskStackC[2] = false;
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+R13i.x = floatBitsToInt(intBitsToFloat(R0i.x) + intBitsToFloat(R6i.x));
+R13i.y = floatBitsToInt(intBitsToFloat(R0i.y) + intBitsToFloat(R1i.y));
+R14i.x = floatBitsToInt(intBitsToFloat(R0i.x) + -(intBitsToFloat(R6i.x)));
+PS0i = R14i.x;
+// 1
+R15i.x = floatBitsToInt(intBitsToFloat(R0i.x) + intBitsToFloat(R5i.x));
+R14i.y = floatBitsToInt(intBitsToFloat(R0i.y) + -(intBitsToFloat(R1i.y)));
+R15i.y = floatBitsToInt(intBitsToFloat(R0i.y) + intBitsToFloat(R5i.y));
+PS1i = R15i.y;
+// 2
+R16i.x = floatBitsToInt(intBitsToFloat(R0i.x) + -(intBitsToFloat(R5i.x)));
+R16i.y = floatBitsToInt(intBitsToFloat(R0i.y) + -(intBitsToFloat(R5i.y)));
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.x = floatBitsToInt(intBitsToFloat(R4i.x) * 1.5);
+PV0i.y = floatBitsToInt(intBitsToFloat(R4i.y) * 1.5);
+PV0i.z = ((-(intBitsToFloat(R12i.z)) > uf_blockPS1[58].x)?int(0xFFFFFFFF):int(0x0));
+R127i.w = ((-(intBitsToFloat(R12i.z)) > uf_blockPS1[58].y)?int(0xFFFFFFFF):int(0x0));
+PS0i = floatBitsToInt(intBitsToFloat(R2i.z) * 1.5);
+// 1
+backupReg0i = R1i.x;
+backupReg1i = R1i.z;
+R1i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(backupReg0i)),intBitsToFloat(R2i.w)) + intBitsToFloat(PV0i.x)));
+PV1i.y = PV0i.z & int(1);
+R1i.z = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R3i.y)),intBitsToFloat(R2i.w)) + intBitsToFloat(PV0i.y)));
+R1i.w = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(backupReg1i)),intBitsToFloat(R2i.w)) + intBitsToFloat(PS0i)));
+PV1i.w = R1i.w;
+R122i.x = floatBitsToInt((intBitsToFloat(R3i.z) * 0.25 + 1.0));
+PS1i = R122i.x;
+// 2
+backupReg0i = R2i.y;
+R2i.x = floatBitsToInt(uf_blockPS6[53].y/resScale);
+R2i.x = floatBitsToInt(intBitsToFloat(R2i.x) / 2.0);
+PV0i.x = R2i.x;
+R2i.y = floatBitsToInt(uf_blockPS6[53].x/resScale);
+R2i.y = floatBitsToInt(intBitsToFloat(R2i.y) / 2.0);
+PV0i.y = R2i.y;
+R3i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), intBitsToFloat(PS1i)));
+R3i.w = PV1i.y - R127i.w;
+PV0i.w = R3i.w;
+PS0i = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.w), intBitsToFloat(PV1i.w)));
+// 3
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R1i.z),intBitsToFloat(R1i.z)) + intBitsToFloat(PS0i)));
+PV1i.x = R123i.x;
+R3i.y = floatBitsToInt(-(intBitsToFloat(PV0i.x)));
+R7i.z = floatBitsToInt(-(intBitsToFloat(PV0i.y)));
+PV1i.w = PV0i.w << 0x00000002;
+R1i.y = floatBitsToInt(float(PV0i.w));
+PS1i = R1i.y;
+// 4
+R0i.x = PV1i.w + 0x0000002c;
+R0i.y = PV1i.w + 0x0000002b;
+R0i.z = PV1i.w + 0x0000002a;
+R0i.w = PV1i.w + 0x0000002d;
+R122i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R1i.x),intBitsToFloat(R1i.x)) + intBitsToFloat(PV1i.x)));
+PS0i = R122i.x;
+// 5
+backupReg0i = R2i.z;
+backupReg0i = R2i.z;
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R4i.x),intBitsToFloat(R4i.y),intBitsToFloat(backupReg0i),intBitsToFloat(backupReg0i)),vec4(-(intBitsToFloat(R8i.x)),-(intBitsToFloat(R9i.y)),-(intBitsToFloat(R10i.z)),-(intBitsToFloat(R4i.w)))));
+tempi.x = clampFI32(tempi.x);
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R2i.z = tempi.x;
+tempResultf = 1.0 / sqrt(intBitsToFloat(PS0i));
+R2i.w = floatBitsToInt(tempResultf);
+PS1i = R2i.w;
+}
+if( activeMaskStackC[2] == true ) {
+R4i.xyzw = floatBitsToInt(uf_blockPS1[R0i.w].xyzw);
+R5i.xyzw = floatBitsToInt(uf_blockPS1[R0i.x].xyzw);
+R6i.xyzw = floatBitsToInt(uf_blockPS1[R0i.z].xyzw);
+R0i.xyzw = floatBitsToInt(uf_blockPS1[R0i.y].xyzw);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+R127i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.x), intBitsToFloat(R2i.w)));
+PV0i.x = R127i.x;
+R127i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.z), intBitsToFloat(R2i.w)));
+PV0i.y = R127i.y;
+R127i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.w), intBitsToFloat(R2i.w)));
+PV0i.z = R127i.z;
+R127i.w = R2i.x;
+R8i.z = floatBitsToInt(roundEven(intBitsToFloat(R1i.y)));
+PS0i = R8i.z;
+// 1
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R8i.x),intBitsToFloat(R9i.y),intBitsToFloat(R10i.z),-0.0),vec4(intBitsToFloat(PV0i.x),intBitsToFloat(PV0i.y),intBitsToFloat(PV0i.z),0.0)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R9i.z = PS0i;
+PS1i = R9i.z;
+// 2
+R123i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R10i.z)),intBitsToFloat(PV1i.x)) + intBitsToFloat(R127i.z)));
+PV0i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R9i.y)),intBitsToFloat(PV1i.x)) + intBitsToFloat(R127i.y)));
+PV0i.y = R123i.y;
+R123i.z = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(PV1i.x)),intBitsToFloat(PV1i.x)) + 1.0));
+PV0i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R8i.x)),intBitsToFloat(PV1i.x)) + intBitsToFloat(R127i.x)));
+PV0i.w = R123i.w;
+R10i.z = R8i.z;
+PS0i = R10i.z;
+// 3
+R127i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.z), intBitsToFloat(PV0i.w)));
+R127i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.z), intBitsToFloat(PV0i.y)));
+R127i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.z), intBitsToFloat(PV0i.x)));
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.z), intBitsToFloat(R2i.z)));
+R11i.z = R8i.z;
+PS1i = R11i.z;
+// 4
+PV0i.x = floatBitsToInt(intBitsToFloat(PV1i.w) * intBitsToFloat(0x3da1ff2e));
+// 5
+backupReg0i = R12i.z;
+R17i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.x),intBitsToFloat(PV0i.x)) + intBitsToFloat(R3i.x)));
+PV1i.x = R17i.x;
+R12i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.y),intBitsToFloat(PV0i.x)) + intBitsToFloat(R8i.y)));
+R12i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.z),intBitsToFloat(PV0i.x)) + intBitsToFloat(backupReg0i)));
+// 6
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.x), intBitsToFloat(R5i.x)));
+R127i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.x), intBitsToFloat(R6i.x)));
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.x), intBitsToFloat(R4i.x)));
+// 7
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.y),intBitsToFloat(R5i.y)) + intBitsToFloat(PV0i.x)));
+PV1i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.y),intBitsToFloat(R4i.y)) + intBitsToFloat(PV0i.z)));
+PV1i.y = R123i.y;
+R127i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R17i.x), intBitsToFloat(R0i.x)));
+// 8
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.z),intBitsToFloat(R4i.z)) + intBitsToFloat(PV1i.y)));
+PV0i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.z),intBitsToFloat(R5i.z)) + intBitsToFloat(PV1i.x)));
+PV0i.y = R123i.y;
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.y),intBitsToFloat(R6i.y)) + intBitsToFloat(R127i.y)));
+PV0i.z = R123i.z;
+// 9
+R127i.x = floatBitsToInt(intBitsToFloat(R5i.w) + intBitsToFloat(PV0i.y));
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.y),intBitsToFloat(R0i.y)) + intBitsToFloat(R127i.z)));
+PV1i.y = R123i.y;
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.z),intBitsToFloat(R6i.z)) + intBitsToFloat(PV0i.z)));
+PV1i.z = R123i.z;
+PV1i.w = floatBitsToInt(intBitsToFloat(R4i.w) + intBitsToFloat(PV0i.x));
+// 10
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.z),intBitsToFloat(R0i.z)) + intBitsToFloat(PV1i.y)));
+PV0i.x = R123i.x;
+PV0i.w = floatBitsToInt(intBitsToFloat(R6i.w) + intBitsToFloat(PV1i.z));
+R127i.z = floatBitsToInt(1.0 / intBitsToFloat(PV1i.w));
+PS0i = R127i.z;
+// 11
+PV1i.x = floatBitsToInt(intBitsToFloat(R0i.w) + intBitsToFloat(PV0i.x));
+R127i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.w), intBitsToFloat(PS0i)));
+PV1i.y = R127i.y;
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(PS0i)));
+// 12
+R127i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.x), intBitsToFloat(R127i.z)));
+PV0i.x = R127i.x;
+PV0i.z = floatBitsToInt(intBitsToFloat(PV1i.w) + intBitsToFloat(0xbb03126f));
+R8i.x = floatBitsToInt((uf_blockPS6[53].x / resScale * 0.5 + intBitsToFloat(PV1i.y)));
+PS0i = R8i.x;
+// 13
+R126i.x = floatBitsToInt((-(intBitsToFloat(R1i.y)) * intBitsToFloat(0x3a03126f) + intBitsToFloat(PV0i.z)));
+R126i.x = clampFI32(R126i.x);
+PV1i.x = R126i.x;
+R8i.y = floatBitsToInt((uf_blockPS6[53].y / resScale * 0.5 + intBitsToFloat(PV0i.x)));
+R9i.x = floatBitsToInt(intBitsToFloat(R127i.y) + intBitsToFloat(R2i.y));
+PS1i = R9i.x;
+// 14
+R10i.x = floatBitsToInt(intBitsToFloat(R127i.y) + intBitsToFloat(R7i.z));
+R9i.y = floatBitsToInt(intBitsToFloat(R127i.x) + intBitsToFloat(R3i.y));
+R8i.w = PV1i.x;
+R9i.w = PV1i.x;
+PS0i = R9i.w;
+// 15
+R11i.x = floatBitsToInt((-(uf_blockPS6[53].x) / resScale * 0.5 + intBitsToFloat(R127i.y)));
+R10i.y = floatBitsToInt(intBitsToFloat(R127i.x) + intBitsToFloat(R127i.w));
+R10i.w = R126i.x;
+R11i.y = floatBitsToInt((-(uf_blockPS6[53].y) / resScale * 0.5 + intBitsToFloat(R127i.x)));
+PS1i = R11i.y;
+// 16
+R11i.w = R126i.x;
+}
+if( activeMaskStackC[2] == true ) {
+R8i.z = floatBitsToInt(texture(textureUnitPS8, vec4(intBitsToFloat(R8i.x),intBitsToFloat(R8i.y),intBitsToFloat(R8i.z),intBitsToFloat(R8i.w))));
+R9i.y = floatBitsToInt(texture(textureUnitPS8, vec4(intBitsToFloat(R9i.x),intBitsToFloat(R9i.y),intBitsToFloat(R9i.z),intBitsToFloat(R9i.w))));
+R10i.x = floatBitsToInt(texture(textureUnitPS8, vec4(intBitsToFloat(R10i.x),intBitsToFloat(R10i.y),intBitsToFloat(R10i.z),intBitsToFloat(R10i.w))));
+R11i.w = floatBitsToInt(texture(textureUnitPS8, vec4(intBitsToFloat(R11i.x),intBitsToFloat(R11i.y),intBitsToFloat(R11i.z),intBitsToFloat(R11i.w))));
+}
+if( activeMaskStackC[2] == true ) {
+activeMaskStack[2] = activeMaskStack[1];
+activeMaskStackC[3] = activeMaskStackC[2];
+// 0
+PV0i.w = floatBitsToInt(intBitsToFloat(R8i.z) + intBitsToFloat(R9i.y));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV0i.w) / 2.0);
+// 1
+R123i.y = floatBitsToInt((intBitsToFloat(R10i.x) * 0.5 + intBitsToFloat(PV0i.w)));
+PV1i.y = R123i.y;
+// 2
+R4i.z = floatBitsToInt((intBitsToFloat(R11i.w) * 0.5 + intBitsToFloat(PV1i.y))/2.0);
+PV0i.z = R4i.z;
+// 3
+PV1i.x = ((1.0 > intBitsToFloat(PV0i.z))?int(0xFFFFFFFF):int(0x0));
+// 4
+R0i.w = ((R3i.w > 0)?(PV1i.x):(0));
+// 5
+predResult = (R0i.w != 0);
+activeMaskStack[2] = predResult;
+activeMaskStackC[3] = predResult == true && activeMaskStackC[2] == true;
+}
+else {
+activeMaskStack[2] = false;
+activeMaskStackC[3] = false;
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+PV0i.z = int(-1) + R3i.w;
+// 1
+PV1i.y = PV0i.z << 0x00000002;
+R4i.x = floatBitsToInt(float(PV0i.z));
+PS1i = R4i.x;
+// 2
+R0i.x = PV1i.y + 0x0000002a;
+R0i.y = PV1i.y + 0x0000002d;
+R0i.z = PV1i.y + 0x0000002c;
+R0i.w = PV1i.y + 0x0000002b;
+R5i.z = floatBitsToInt(roundEven(intBitsToFloat(PS1i)));
+PS0i = R5i.z;
+}
+if( activeMaskStackC[3] == true ) {
+R1i.xyzw = floatBitsToInt(uf_blockPS1[R0i.y].xyzw);
+R2i.xyzw = floatBitsToInt(uf_blockPS1[R0i.z].xyzw);
+R3i.xyzw = floatBitsToInt(uf_blockPS1[R0i.x].xyzw);
+R0i.xyzw = floatBitsToInt(uf_blockPS1[R0i.w].xyzw);
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R17i.x), intBitsToFloat(R1i.x)));
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R17i.x), intBitsToFloat(R2i.x)));
+// 1
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.y),intBitsToFloat(R2i.y)) + intBitsToFloat(PV0i.y)));
+PV1i.x = R123i.x;
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R17i.x), intBitsToFloat(R3i.x)));
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R17i.x), intBitsToFloat(R0i.x)));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.y),intBitsToFloat(R1i.y)) + intBitsToFloat(PV0i.x)));
+PV1i.w = R123i.w;
+// 2
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.z),intBitsToFloat(R2i.z)) + intBitsToFloat(PV1i.x)));
+PV0i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.y),intBitsToFloat(R0i.y)) + intBitsToFloat(PV1i.z)));
+PV0i.y = R123i.y;
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.z),intBitsToFloat(R1i.z)) + intBitsToFloat(PV1i.w)));
+PV0i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.y),intBitsToFloat(R3i.y)) + intBitsToFloat(PV1i.y)));
+PV0i.w = R123i.w;
+// 3
+R127i.x = floatBitsToInt(intBitsToFloat(R2i.w) + intBitsToFloat(PV0i.x));
+PV1i.y = floatBitsToInt(intBitsToFloat(R1i.w) + intBitsToFloat(PV0i.z));
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.z),intBitsToFloat(R3i.z)) + intBitsToFloat(PV0i.w)));
+PV1i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.z),intBitsToFloat(R0i.z)) + intBitsToFloat(PV0i.y)));
+PV1i.w = R123i.w;
+// 4
+PV0i.x = floatBitsToInt(intBitsToFloat(R0i.w) + intBitsToFloat(PV1i.w));
+PV0i.y = floatBitsToInt(intBitsToFloat(R3i.w) + intBitsToFloat(PV1i.z));
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PV1i.y));
+// 5
+R5i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.y), intBitsToFloat(PS0i)));
+R5i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.x), intBitsToFloat(PS0i)));
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(PS0i)));
+// 6
+PV0i.y = floatBitsToInt(intBitsToFloat(PV1i.w) + intBitsToFloat(0xbb03126f));
+// 7
+R5i.w = floatBitsToInt((-(intBitsToFloat(R4i.x)) * intBitsToFloat(0x3a03126f) + intBitsToFloat(PV0i.y)));
+R5i.w = clampFI32(R5i.w);
+}
+if( activeMaskStackC[3] == true ) {
+R5i.z = floatBitsToInt(texture(textureUnitPS8, vec4(intBitsToFloat(R5i.x),intBitsToFloat(R5i.y),intBitsToFloat(R5i.z),intBitsToFloat(R5i.w))));
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+backupReg0i = R4i.z;
+R4i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), intBitsToFloat(R5i.z)));
+}
+activeMaskStackC[2] = activeMaskStack[1] == true && activeMaskStackC[1] == true;
+if( activeMaskStackC[2] == true ) {
+R0i.x = floatBitsToInt(texture(textureUnitPS6, intBitsToFloat(R15i.xy)).x);
+R0i.y = floatBitsToInt(texture(textureUnitPS6, intBitsToFloat(R16i.xy)).x);
+R1i.x = floatBitsToInt(texture(textureUnitPS6, intBitsToFloat(R13i.xy)).x);
+R1i.y = floatBitsToInt(texture(textureUnitPS6, intBitsToFloat(R14i.xy)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+R127i.x = floatBitsToInt(intBitsToFloat(R7i.w) * intBitsToFloat(0x3f7eb852));
+PV0i.x = R127i.x;
+PV0i.y = floatBitsToInt(uf_blockPS1[16].x * intBitsToFloat(0x41a00000));
+R124i.z = floatBitsToInt(-(intBitsToFloat(R4i.z)) + 1.0);
+R127i.w = floatBitsToInt(uf_blockPS1[16].x * intBitsToFloat(0x3f555555));
+// 1
+backupReg0i = R0i.x;
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.x) + -(intBitsToFloat(R0i.y)));
+PV1i.y = floatBitsToInt(intBitsToFloat(PV0i.x) + -(intBitsToFloat(backupReg0i)));
+R127i.z = floatBitsToInt(intBitsToFloat(PV0i.y) * intBitsToFloat(0x3f8ba8d6));
+R127i.z = floatBitsToInt(intBitsToFloat(R127i.z) / 2.0);
+PV1i.w = floatBitsToInt(intBitsToFloat(PV0i.y) * intBitsToFloat(0x3fbc4580));
+PV1i.w = floatBitsToInt(intBitsToFloat(PV1i.w) / 2.0);
+R126i.z = floatBitsToInt(-(intBitsToFloat(R1i.x)) + intBitsToFloat(PV0i.x));
+PS1i = R126i.z;
+// 2
+backupReg0i = R127i.x;
+R127i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R127i.w)),intBitsToFloat(PV1i.y)) + 1.0));
+R127i.x = clampFI32(R127i.x);
+R127i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.w),intBitsToFloat(PV1i.x)) + 0.5));
+R127i.y = clampFI32(R127i.y);
+PV0i.y = R127i.y;
+R125i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.w),intBitsToFloat(PV1i.y)) + 0.5));
+R125i.z = clampFI32(R125i.z);
+PV0i.z = R125i.z;
+R126i.w = floatBitsToInt(-(intBitsToFloat(R1i.y)) + intBitsToFloat(backupReg0i));
+PV0i.w = R126i.w;
+R125i.w = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R127i.w)),intBitsToFloat(PV1i.x)) + 1.0));
+R125i.w = clampFI32(R125i.w);
+PS0i = R125i.w;
+// 3
+R126i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.z),intBitsToFloat(R126i.z)) + 0.5));
+R126i.x = clampFI32(R126i.x);
+PV1i.x = R126i.x;
+PV1i.y = floatBitsToInt(0.5 + -(intBitsToFloat(PV0i.y)));
+PV1i.z = floatBitsToInt(0.5 + -(intBitsToFloat(PV0i.z)));
+R124i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.z),intBitsToFloat(PV0i.w)) + 0.5));
+R124i.w = clampFI32(R124i.w);
+PV1i.w = R124i.w;
+R0i.w = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R127i.w)),intBitsToFloat(R126i.z)) + 1.0));
+R0i.w = clampFI32(R0i.w);
+PS1i = R0i.w;
+// 4
+backupReg0i = R127i.w;
+PV0i.x = floatBitsToInt(0.5 + -(intBitsToFloat(PV1i.x)));
+R126i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.z),intBitsToFloat(R127i.x)) + 0.5));
+PV0i.y = R126i.y;
+PV0i.z = floatBitsToInt(0.5 + -(intBitsToFloat(PV1i.w)));
+R127i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.y),intBitsToFloat(R125i.w)) + 0.5));
+PV0i.w = R127i.w;
+R125i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(backupReg0i)),intBitsToFloat(R126i.w)) + 1.0));
+R125i.y = clampFI32(R125i.y);
+PS0i = R125i.y;
+// 5
+PV1i.x = floatBitsToInt(intBitsToFloat(R127i.y) + -(intBitsToFloat(PV0i.y)));
+R127i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.z),intBitsToFloat(PS0i)) + 0.5));
+PV1i.y = R127i.y;
+PV1i.z = floatBitsToInt(intBitsToFloat(R125i.z) + -(intBitsToFloat(PV0i.w)));
+R126i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.x),intBitsToFloat(R0i.w)) + 0.5));
+PV1i.w = R126i.w;
+R3i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R124i.z),intBitsToFloat(R12i.w)) + intBitsToFloat(R4i.z)));
+PS1i = R3i.w;
+// 6
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.z),intBitsToFloat(R127i.x)) + intBitsToFloat(R127i.w)));
+PV0i.x = R123i.x;
+PV0i.y = floatBitsToInt(intBitsToFloat(R126i.x) + -(intBitsToFloat(PV1i.y)));
+PV0i.z = floatBitsToInt(intBitsToFloat(R124i.w) + -(intBitsToFloat(PV1i.w)));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.x),intBitsToFloat(R125i.w)) + intBitsToFloat(R126i.y)));
+PV0i.w = R123i.w;
+// 7
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.x) * intBitsToFloat(0x3e35e743));
+PV1i.y = floatBitsToInt(intBitsToFloat(PV0i.w) * intBitsToFloat(0x3e35e743));
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.z),intBitsToFloat(R125i.y)) + intBitsToFloat(R126i.w)));
+PV1i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.y),intBitsToFloat(R0i.w)) + intBitsToFloat(R127i.y)));
+PV1i.w = R123i.w;
+// 8
+R123i.x = floatBitsToInt((intBitsToFloat(PV1i.w) * intBitsToFloat(0x3e825397) + intBitsToFloat(PV1i.x)));
+PV0i.x = R123i.x;
+R123i.w = floatBitsToInt((intBitsToFloat(PV1i.z) * intBitsToFloat(0x3e825397) + intBitsToFloat(PV1i.y)));
+PV0i.w = R123i.w;
+// 9
+PV1i.z = floatBitsToInt(intBitsToFloat(PV0i.x) + intBitsToFloat(PV0i.w));
+// 10
+PV0i.y = floatBitsToInt(intBitsToFloat(PV1i.z) + intBitsToFloat(0xbedd476b));
+// 11
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.y) * intBitsToFloat(0x40c00000));
+PV1i.x = clampFI32(PV1i.x);
+// 12
+R1i.w = floatBitsToInt(-(intBitsToFloat(PV1i.x)) + 1.0);
+}
+activeMaskStack[1] = activeMaskStack[1] == false;
+activeMaskStackC[2] = activeMaskStack[1] == true && activeMaskStackC[1] == true;
+if( activeMaskStackC[2] == true ) {
+// 0
+R3i.w = R1i.w;
+}
+activeMaskStackC[1] = activeMaskStack[0] == true && activeMaskStackC[0] == true;
+if( activeMaskStackC[1] == true ) {
+// 0
+R0i.x = floatBitsToInt((intBitsToFloat(R7i.x) * intBitsToFloat(0x38d1b717) + 0.5));
+R0i.y = floatBitsToInt((intBitsToFloat(R13i.z) * intBitsToFloat(0x3903126f) + 0.5));
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R7i.y)));
+PV0i.z = floatBitsToInt(intBitsToFloat(PV0i.z) / 2.0);
+PV0i.w = R12i.x;
+PV0i.w = floatBitsToInt(intBitsToFloat(PV0i.w) / 2.0);
+R2i.z = R1i.w;
+PS0i = R2i.z;
+// 1
+R1i.x = floatBitsToInt(intBitsToFloat(PV0i.w) + 0.5);
+R1i.y = floatBitsToInt(intBitsToFloat(PV0i.z) + 0.5);
+R2i.w = 0x3f800000;
+}
+if( activeMaskStackC[1] == true ) {
+R0i.xyz = floatBitsToInt(textureLod(textureUnitPS15, intBitsToFloat(R0i.xy),0.0).xyz);
+R1i.y = floatBitsToInt(textureLod(textureUnitPS1, intBitsToFloat(R1i.xy),0.0).x);
+}
+if( activeMaskStackC[1] == true ) {
+// 0
+backupReg0i = R0i.x;
+backupReg1i = R0i.y;
+backupReg2i = R0i.z;
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(backupReg0i),intBitsToFloat(backupReg1i),intBitsToFloat(backupReg2i),-0.0),vec4(uf_blockPS6[42].x,uf_blockPS6[42].y,uf_blockPS6[42].z,0.0)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+R2i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R1i.y),-(intBitsToFloat(R13i.w))) + intBitsToFloat(R1i.y)));
+PS0i = R2i.y;
+// 1
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.x), intBitsToFloat(PV0i.x)));
+// 2
+R127i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.w), intBitsToFloat(PV1i.w)));
+PV0i.z = R127i.z;
+// 3
+PV1i.y = floatBitsToInt(intBitsToFloat(R3i.w) + -(intBitsToFloat(PV0i.z)));
+// 4
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.y),intBitsToFloat(R14i.w)) + intBitsToFloat(R127i.z)));
+PV0i.x = R123i.x;
+// 5
+R2i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.x),uf_blockPS10[3].z) + uf_blockPS10[1].y));
+R2i.x = clampFI32(R2i.x);
+}
+// export
+passPixelColor5 = vec4(intBitsToFloat(R2i.x), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w));
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/8cab2ed476b991ea_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/8cab2ed476b991ea_0000000000000000_vs.txt
@@ -1,0 +1,109 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader 8cab2ed476b991ea
+// Used for: Restoring the native BotW Anti-Aliasing implementation
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 1) out vec4 passParameterSem1;
+layout(location = 0) out vec4 passParameterSem0;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R2f = vec4(0.0);
+uvec4 attrDecoder;
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = floatBitsToInt(ivec4(gl_VertexID, 0, 0, gl_InstanceID));
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R1f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(floatBitsToInt(1.0)));
+attrDecoder.xy = attrDataSem1.xy;
+attrDecoder.xy = (attrDecoder.xy>>24)|((attrDecoder.xy>>8)&0xFF00)|((attrDecoder.xy<<8)&0xFF0000)|((attrDecoder.xy<<24));
+attrDecoder.z = 0;
+attrDecoder.w = 0;
+R2f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(floatBitsToInt(0.0)), intBitsToFloat(floatBitsToInt(1.0)));
+// 0
+backupReg0f = R1f.x;
+backupReg1f = R1f.y;
+R1f.x = backupReg0f;
+R1f.x *= 2.0;
+R1f.y = backupReg1f;
+R1f.y *= 2.0;
+R1f.z = 1.0;
+R0f.w = R2f.x;
+PV0f.w = R0f.w;
+R0f.y = R2f.y;
+PS0f = R0f.y;
+// 1
+PV1f.x = -(intBitsToFloat(uf_remappedVS[0].w)/resYScale);
+PV1f.x /= 2.0;
+PV1f.y = -(intBitsToFloat(uf_remappedVS[0].z)/resXScale);
+PV1f.y /= 2.0;
+R2f.x = (mul_nonIEEE(PV0f.w,intBitsToFloat(uf_remappedVS[0].x)*resXScale) + 0.5);
+PS1f = R2f.x;
+// 2
+R2f.y = (mul_nonIEEE(R0f.y,intBitsToFloat(uf_remappedVS[0].y)*resYScale) + 0.5);
+R2f.z = PV1f.y;
+R2f.w = PV1f.x;
+// export
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.z));
+// export
+passParameterSem1 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
+// export
+passParameterSem0 = vec4(R0f.w, R0f.y, R0f.z, R0f.z);
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/93f16bf1d083933b_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/93f16bf1d083933b_0000000000000000_vs.txt
@@ -1,0 +1,120 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader 93f16bf1d083933b
+// Used for: Horizontal Self-Shadowing Mask Fix Blur
+// Self shadowing mask fix - h blur
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 1) out vec4 passParameterSem1;
+layout(location = 0) out vec4 passParameterSem0;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R2f = vec4(0.0);
+vec4 R3f = vec4(0.0);
+vec4 R4f = vec4(0.0);
+vec4 R127f = vec4(0.0);
+uvec4 attrDecoder;
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = floatBitsToInt(ivec4(gl_VertexID, 0, 0, gl_InstanceID));
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R1f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(floatBitsToInt(1.0)));
+attrDecoder.xy = attrDataSem1.xy;
+attrDecoder.xy = (attrDecoder.xy>>24)|((attrDecoder.xy>>8)&0xFF00)|((attrDecoder.xy<<8)&0xFF0000)|((attrDecoder.xy<<24));
+attrDecoder.z = 0;
+attrDecoder.w = 0;
+R2f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(floatBitsToInt(0.0)), intBitsToFloat(floatBitsToInt(1.0)));
+// 0
+backupReg0f = R1f.x;
+backupReg1f = R1f.y;
+R1f.x = backupReg0f;
+R1f.x *= 2.0;
+R1f.y = backupReg1f;
+R1f.y *= 2.0;
+R1f.z = intBitsToFloat(0xbf5fdfe0);
+R1f.w = 1.0;
+R127f.y = intBitsToFloat(uf_remappedVS[0].x) * intBitsToFloat(0x3fb13a93) / resXScale;
+PS0f = R127f.y;
+// 1
+R127f.x = intBitsToFloat(uf_remappedVS[0].x) * intBitsToFloat(0x404ec4f0) / resXScale;
+PV1f.x = R127f.x;
+R4f.y = R2f.y;
+R4f.z = R2f.x;
+R3f.w = R2f.x;
+R3f.x = R2f.y;
+PS1f = R3f.x;
+// 2
+R0f.x = PS1f;
+R3f.y = R2f.x + -(R127f.y);
+R3f.z = R2f.x + R127f.y;
+R0f.w = R2f.x;
+R0f.y = R2f.x + -(PV1f.x);
+PS0f = R0f.y;
+// 3
+R0f.z = R2f.x + R127f.x;
+// export
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
+// export
+passParameterSem1 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
+// export
+passParameterSem0 = vec4(R3f.x, R3f.y, R3f.z, R3f.w);
+// export
+// skipped export to semanticId 255
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/a1cb9f79d093badb_0000f0f0ff34db6d_ps.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/a1cb9f79d093badb_0000f0f0ff34db6d_ps.txt
@@ -1,0 +1,562 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader a1cb9f79d093badb
+// Used for: Restoring the native BotW Anti-Aliasing implementation from water edges
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 1, binding = 8) uniform ufBlock
+{
+uniform ivec4 uf_remappedPS[20];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[20];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(2, 1, 1) uniform sampler2DArray textureUnitPS2;
+TEXTURE_LAYOUT(3, 1, 2) uniform sampler2D textureUnitPS3;
+TEXTURE_LAYOUT(7, 1, 3) uniform sampler2DArray textureUnitPS7;
+TEXTURE_LAYOUT(8, 1, 4) uniform sampler2DArray textureUnitPS8;
+TEXTURE_LAYOUT(9, 1, 5) uniform sampler2DArray textureUnitPS9;
+TEXTURE_LAYOUT(10, 1, 6) uniform sampler2DArray textureUnitPS10;
+TEXTURE_LAYOUT(11, 1, 7) uniform sampler2DArray textureUnitPS11;
+layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
+layout(location = 2) in vec4 passParameterSem2;
+layout(location = 3) in vec4 passParameterSem3;
+layout(location = 4) in vec4 passParameterSem4;
+layout(location = 5) in vec4 passParameterSem5;
+layout(location = 6) in vec4 passParameterSem11;
+layout(location = 7) in vec4 passParameterSem7;
+layout(location = 8) in vec4 passParameterSem8;
+layout(location = 9) in vec4 passParameterSem9;
+layout(location = 10) in vec4 passParameterSem10;
+layout(location = 0) out vec4 passPixelColor0;
+layout(location = 1) out vec4 passPixelColor1;
+layout(location = 3) out vec4 passPixelColor3;
+layout(location = 5) out vec4 passPixelColor5;
+// uf_fragCoordScale was moved to the ufBlock
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+ivec4 R0i = ivec4(0);
+ivec4 R1i = ivec4(0);
+ivec4 R2i = ivec4(0);
+ivec4 R3i = ivec4(0);
+ivec4 R4i = ivec4(0);
+ivec4 R5i = ivec4(0);
+ivec4 R6i = ivec4(0);
+ivec4 R7i = ivec4(0);
+ivec4 R8i = ivec4(0);
+ivec4 R9i = ivec4(0);
+ivec4 R10i = ivec4(0);
+ivec4 R11i = ivec4(0);
+ivec4 R12i = ivec4(0);
+ivec4 R13i = ivec4(0);
+ivec4 R14i = ivec4(0);
+ivec4 R15i = ivec4(0);
+ivec4 R16i = ivec4(0);
+ivec4 R17i = ivec4(0);
+ivec4 R18i = ivec4(0);
+ivec4 R19i = ivec4(0);
+ivec4 R122i = ivec4(0);
+ivec4 R123i = ivec4(0);
+ivec4 R124i = ivec4(0);
+ivec4 R125i = ivec4(0);
+ivec4 R126i = ivec4(0);
+ivec4 R127i = ivec4(0);
+int backupReg0i, backupReg1i, backupReg2i, backupReg3i, backupReg4i;
+ivec4 PV0i = ivec4(0), PV1i = ivec4(0);
+int PS0i = 0, PS1i = 0;
+ivec4 tempi = ivec4(0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0i = floatBitsToInt(passParameterSem0);
+R1i = floatBitsToInt(passParameterSem1);
+R2i = floatBitsToInt(passParameterSem2);
+R3i = floatBitsToInt(passParameterSem3);
+R4i = floatBitsToInt(passParameterSem4);
+R5i = floatBitsToInt(passParameterSem5);
+R6i = floatBitsToInt(passParameterSem11);
+R7i = floatBitsToInt(passParameterSem7);
+R8i = floatBitsToInt(passParameterSem8);
+R9i = floatBitsToInt(passParameterSem9);
+R10i = floatBitsToInt(passParameterSem10);
+// 0
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R8i.x), intBitsToFloat(uf_remappedPS[0].x)));
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R8i.x), intBitsToFloat(uf_remappedPS[1].x)));
+R127i.z = R9i.z;
+R127i.w = R9i.w;
+R126i.z = 0;
+PS0i = R126i.z;
+// 1
+R127i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R8i.y),intBitsToFloat(uf_remappedPS[1].y)) + intBitsToFloat(PV0i.y)));
+R127i.y = R9i.y;
+R15i.z = floatBitsToInt(roundEven(1.0));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R8i.y),intBitsToFloat(uf_remappedPS[0].y)) + intBitsToFloat(PV0i.x)));
+PV1i.w = R123i.w;
+R126i.x = floatBitsToInt(1.0 / intBitsToFloat(R6i.w));
+PS1i = R126i.x;
+// 2
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R127i.z),intBitsToFloat(R127i.w),intBitsToFloat(R126i.z),-0.0),vec4(intBitsToFloat(R127i.z),intBitsToFloat(R127i.w),intBitsToFloat(R126i.z),0.0)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+R122i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R8i.z),intBitsToFloat(uf_remappedPS[0].z)) + intBitsToFloat(PV1i.w)));
+PS0i = R122i.x;
+// 3
+R14i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R6i.x), intBitsToFloat(R126i.x)));
+PV1i.y = floatBitsToInt(intBitsToFloat(uf_remappedPS[0].w) + intBitsToFloat(PS0i));
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R8i.z),intBitsToFloat(uf_remappedPS[1].z)) + intBitsToFloat(R127i.x)));
+PV1i.z = R123i.z;
+R12i.w = floatBitsToInt(roundEven(intBitsToFloat(R127i.y)));
+PV1i.w = R12i.w;
+R19i.z = floatBitsToInt(sqrt(intBitsToFloat(PV0i.x)));
+PS1i = R19i.z;
+// 4
+PV0i.x = floatBitsToInt(intBitsToFloat(PV1i.y) * intBitsToFloat(0x3cdd67c9));
+PV0i.y = floatBitsToInt(intBitsToFloat(uf_remappedPS[1].w) + intBitsToFloat(PV1i.z));
+R11i.z = PV1i.w;
+PV0i.w = floatBitsToInt(intBitsToFloat(PS1i) * intBitsToFloat(0x3fb6db6e));
+PV0i.w = clampFI32(PV0i.w);
+R127i.x = floatBitsToInt(1.0 / intBitsToFloat(PS1i));
+PS0i = R127i.x;
+// 5
+PV1i.x = floatBitsToInt(mul_nonIEEE(-(intBitsToFloat(R8i.z)), intBitsToFloat(uf_remappedPS[2].y)));
+PV1i.y = floatBitsToInt(intBitsToFloat(PV0i.w) * intBitsToFloat(0x3f333333));
+R123i.z = floatBitsToInt((intBitsToFloat(PV0i.y) * intBitsToFloat(0x3cbe82fa) + intBitsToFloat(PV0i.x)));
+PV1i.z = R123i.z;
+R6i.w = R4i.z;
+R14i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R6i.y), intBitsToFloat(R126i.x)));
+PS1i = R14i.y;
+// 6
+PV0i.x = floatBitsToInt(intBitsToFloat(PV1i.z) + intBitsToFloat(uf_remappedPS[3].z));
+R6i.y = R4i.w;
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.y), intBitsToFloat(R127i.x)));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV1i.z) + intBitsToFloat(uf_remappedPS[3].y));
+R12i.z = floatBitsToInt(1.0 / intBitsToFloat(PV1i.x));
+PS0i = R12i.z;
+// 7
+PV1i.x = floatBitsToInt(fract(intBitsToFloat(PV0i.w)));
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R9i.w), intBitsToFloat(PV0i.z)));
+PV1i.z = floatBitsToInt(fract(intBitsToFloat(PV0i.x)));
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R9i.z), intBitsToFloat(PV0i.z)));
+R6i.z = R12i.w;
+PS1i = R6i.z;
+// 8
+R0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.w), intBitsToFloat(PV1i.z)));
+PV0i.x = R0i.x;
+R0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.y), intBitsToFloat(PV1i.x)));
+PV0i.y = R0i.y;
+R9i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.y), intBitsToFloat(PV1i.z)));
+PV0i.z = R9i.z;
+R9i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.w), intBitsToFloat(PV1i.x)));
+PV0i.w = R9i.w;
+R122i.x = floatBitsToInt((intBitsToFloat(PV1i.x) * 2.0 + -(1.0)));
+PS0i = R122i.x;
+// 9
+R12i.x = floatBitsToInt(intBitsToFloat(R1i.x) + intBitsToFloat(PV0i.w));
+R12i.y = floatBitsToInt(intBitsToFloat(R1i.y) + intBitsToFloat(PV0i.y));
+R14i.z = floatBitsToInt(max(intBitsToFloat(PS0i), -(intBitsToFloat(PS0i))));
+R11i.w = floatBitsToInt(intBitsToFloat(R1i.x) + intBitsToFloat(PV0i.x));
+R11i.y = floatBitsToInt(intBitsToFloat(R1i.y) + intBitsToFloat(PV0i.z));
+PS1i = R11i.y;
+R11i.xy = floatBitsToInt(texture(textureUnitPS8, vec3(intBitsToFloat(R11i.w),intBitsToFloat(R11i.y),intBitsToFloat(R11i.z))).xy);
+R9i.xy = floatBitsToInt(texture(textureUnitPS8, vec3(intBitsToFloat(R12i.x),intBitsToFloat(R12i.y),intBitsToFloat(R12i.w))).xy);
+R11i.w = floatBitsToInt(texture(textureUnitPS0, intBitsToFloat(R14i.xy)).x);
+R6i.xy = floatBitsToInt(texture(textureUnitPS10, vec3(intBitsToFloat(R6i.w),intBitsToFloat(R6i.y),intBitsToFloat(R6i.z))).xy);
+R16i.x = floatBitsToInt(texture(textureUnitPS3, intBitsToFloat(R14i.xy)).y);
+// 0
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R11i.w),intBitsToFloat(uf_remappedPS[4].x)) + intBitsToFloat(uf_remappedPS[5].x)));
+PV0i.x = R123i.x;
+PV0i.y = floatBitsToInt(-(intBitsToFloat(R9i.y)) + intBitsToFloat(R11i.y));
+R127i.z = floatBitsToInt(intBitsToFloat(R8i.z) + intBitsToFloat(uf_remappedPS[5].x));
+PV0i.w = floatBitsToInt(-(intBitsToFloat(R9i.x)) + intBitsToFloat(R11i.x));
+R11i.x = floatBitsToInt(intBitsToFloat(R0i.z) + intBitsToFloat(R9i.w));
+PS0i = R11i.x;
+// 1
+backupReg0i = R0i.y;
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.w),intBitsToFloat(R14i.z)) + intBitsToFloat(R9i.x)));
+PV1i.x = R123i.x;
+PV1i.y = floatBitsToInt(-(intBitsToFloat(R8i.z)) + -(intBitsToFloat(PV0i.x)));
+PV1i.y = floatBitsToInt(intBitsToFloat(PV1i.y) / 2.0);
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.y),intBitsToFloat(R14i.z)) + intBitsToFloat(R9i.y)));
+PV1i.z = R123i.z;
+R11i.w = floatBitsToInt(intBitsToFloat(R0i.w) + intBitsToFloat(backupReg0i));
+R11i.z = R12i.w;
+PS1i = R11i.z;
+// 2
+backupReg0i = R0i.x;
+PV0i.x = floatBitsToInt(max(-(intBitsToFloat(PV1i.y)), 0.0));
+R16i.y = floatBitsToInt((intBitsToFloat(PV1i.z) * intBitsToFloat(0x40008102) + intBitsToFloat(0xbf810204)));
+PV0i.y = R16i.y;
+R13i.z = R12i.w;
+R6i.w = floatBitsToInt((intBitsToFloat(PV1i.x) * intBitsToFloat(0x40008102) + intBitsToFloat(0xbf810204)));
+PV0i.w = R6i.w;
+R13i.x = floatBitsToInt(intBitsToFloat(R0i.z) + intBitsToFloat(backupReg0i));
+PS0i = R13i.x;
+// 3
+PV1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R12i.z), intBitsToFloat(PV0i.w)));
+R127i.y = floatBitsToInt(min(intBitsToFloat(PV0i.x), 1.0));
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R12i.z), intBitsToFloat(PV0i.y)));
+R13i.w = floatBitsToInt(intBitsToFloat(R0i.w) + intBitsToFloat(R9i.z));
+R11i.y = floatBitsToInt(mul_nonIEEE(-(intBitsToFloat(R127i.z)), intBitsToFloat(uf_remappedPS[6].x)));
+PS1i = R11i.y;
+// 4
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(uf_remappedPS[7].y),intBitsToFloat(PV1i.z)) + intBitsToFloat(R14i.y)));
+PV0i.x = R123i.x;
+R126i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.y),intBitsToFloat(uf_remappedPS[8].y)) + intBitsToFloat(R1i.w)));
+PV0i.y = R126i.y;
+R127i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.x),intBitsToFloat(uf_remappedPS[8].x)) + intBitsToFloat(R1i.z)));
+PV0i.z = R127i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(uf_remappedPS[7].x),intBitsToFloat(PV1i.x)) + intBitsToFloat(R14i.x)));
+PV0i.w = R123i.w;
+R4i.z = R12i.w;
+PS0i = R4i.z;
+// 5
+backupReg0i = R0i.y;
+PV1i.x = floatBitsToInt(-(intBitsToFloat(R14i.y)) + intBitsToFloat(PV0i.x));
+PV1i.y = floatBitsToInt(-(intBitsToFloat(R14i.x)) + intBitsToFloat(PV0i.w));
+R0i.z = R12i.w;
+R0i.w = floatBitsToInt(intBitsToFloat(R9i.w) + intBitsToFloat(PV0i.z));
+R0i.y = floatBitsToInt(intBitsToFloat(backupReg0i) + intBitsToFloat(PV0i.y));
+PS1i = R0i.y;
+// 6
+backupReg0i = R9i.z;
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.x),intBitsToFloat(R127i.y)) + intBitsToFloat(R14i.y)));
+PV0i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.y),intBitsToFloat(R127i.y)) + intBitsToFloat(R14i.x)));
+PV0i.y = R123i.y;
+R9i.z = R12i.w;
+R9i.w = floatBitsToInt(intBitsToFloat(R0i.x) + intBitsToFloat(R127i.z));
+R9i.y = floatBitsToInt(intBitsToFloat(backupReg0i) + intBitsToFloat(R126i.y));
+PS0i = R9i.y;
+// 7
+R0i.x = floatBitsToInt(-(intBitsToFloat(R14i.y)) + intBitsToFloat(PV0i.x));
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(uf_remappedPS[9].x)*resXScale, intBitsToFloat(PV0i.y)));
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(uf_remappedPS[9].y)*resYScale, intBitsToFloat(PV0i.x)));
+R12i.w = floatBitsToInt(-(intBitsToFloat(R14i.x)) + intBitsToFloat(PV0i.y));
+R12i.x = uf_remappedPS[10].x;
+PS1i = R12i.x;
+// 8
+PV0i.x = floatBitsToInt(floor(intBitsToFloat(PV1i.y)));
+PV0i.y = floatBitsToInt(floor(intBitsToFloat(PV1i.z)));
+R1i.z = uf_remappedPS[10].y;
+R1i.w = uf_remappedPS[10].z;
+R2i.w = 0x3f800000;
+PS0i = R2i.w;
+// 9
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.y) + 0.5);
+R12i.y = 0x3f800000;
+R16i.z = R2i.x;
+PV1i.w = floatBitsToInt(intBitsToFloat(PV0i.x) + 0.5);
+R18i.z = R10i.x;
+PS1i = R18i.z;
+// 10
+backupReg0i = R2i.y;
+R2i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(uf_remappedPS[9].z)/resXScale, intBitsToFloat(PV1i.w)));
+R2i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(uf_remappedPS[9].w)/resYScale, intBitsToFloat(PV1i.x)));
+R17i.z = R2i.z;
+R5i.w = backupReg0i;
+R8i.w = R10i.y;
+PS0i = R8i.w;
+R2i.z = floatBitsToInt(texture(textureUnitPS0, intBitsToFloat(R2i.xy)).x);
+R2i.xy = floatBitsToInt(texture(textureUnitPS7, vec3(intBitsToFloat(R11i.x),intBitsToFloat(R11i.w),intBitsToFloat(R11i.z))).xy);
+R13i.xy = floatBitsToInt(texture(textureUnitPS7, vec3(intBitsToFloat(R13i.x),intBitsToFloat(R13i.w),intBitsToFloat(R13i.z))).xy);
+R4i.xy = floatBitsToInt(texture(textureUnitPS11, vec3(intBitsToFloat(R4i.x),intBitsToFloat(R4i.y),intBitsToFloat(R4i.z))).xy);
+R6i.xyz = floatBitsToInt(texture(textureUnitPS9, vec3(intBitsToFloat(R0i.w),intBitsToFloat(R0i.y),intBitsToFloat(R0i.z))).xyz);
+R9i.xyz = floatBitsToInt(texture(textureUnitPS9, vec3(intBitsToFloat(R9i.w),intBitsToFloat(R9i.y),intBitsToFloat(R9i.z))).xyz);
+// 0
+backupReg0i = R11i.y;
+PV0i.x = floatBitsToInt(-(intBitsToFloat(R2i.x)) + intBitsToFloat(R13i.x));
+R11i.y = R10i.z;
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R2i.y)) + intBitsToFloat(R13i.y));
+PV0i.w = ((intBitsToFloat(backupReg0i) > intBitsToFloat(R2i.z))?int(0xFFFFFFFF):int(0x0));
+R9i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.z),intBitsToFloat(uf_remappedPS[11].x)) + intBitsToFloat(uf_remappedPS[12].x)));
+R9i.w = clampFI32(R9i.w);
+PS0i = R9i.w;
+// 1
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.x),intBitsToFloat(R14i.z)) + intBitsToFloat(R2i.x)));
+PV1i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.z),intBitsToFloat(R14i.z)) + intBitsToFloat(R2i.y)));
+PV1i.y = R123i.y;
+R0i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.z),intBitsToFloat(uf_remappedPS[11].x)) + intBitsToFloat(uf_remappedPS[12].y)));
+R0i.z = clampFI32(R0i.z);
+R123i.w = ((PV0i.w == 0)?(0x3f800000):(0));
+PV1i.w = R123i.w;
+R2i.x = floatBitsToInt((intBitsToFloat(R4i.x) * intBitsToFloat(0x40008102) + intBitsToFloat(0xbf810204)));
+PS1i = R2i.x;
+// 2
+R15i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.w),intBitsToFloat(PV1i.w)) + intBitsToFloat(R14i.x)));
+R15i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R0i.x),intBitsToFloat(PV1i.w)) + intBitsToFloat(R14i.y)));
+R2i.z = floatBitsToInt((intBitsToFloat(PV1i.x) * intBitsToFloat(0x40008102) + intBitsToFloat(0xbf810204)));
+PV0i.z = R2i.z;
+R12i.w = floatBitsToInt((intBitsToFloat(PV1i.y) * intBitsToFloat(0x40008102) + intBitsToFloat(0xbf810204)));
+R4i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.z),intBitsToFloat(uf_remappedPS[11].x)) + intBitsToFloat(uf_remappedPS[12].z)));
+R4i.z = clampFI32(R4i.z);
+PS0i = R4i.z;
+// 3
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R8i.x),intBitsToFloat(R8i.y),intBitsToFloat(R8i.z),-0.0),vec4(intBitsToFloat(R8i.x),intBitsToFloat(R8i.y),intBitsToFloat(R8i.z),0.0)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R12i.z = tempi.x;
+R2i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.z), intBitsToFloat(PV0i.z)));
+PS1i = R2i.y;
+R14i.y = floatBitsToInt(texture(textureUnitPS0, intBitsToFloat(R15i.xy)).x);
+R15i.xyz = floatBitsToInt(texture(textureUnitPS2, vec3(intBitsToFloat(R15i.x),intBitsToFloat(R15i.y),intBitsToFloat(R15i.z))).xyz);
+// 0
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.w),intBitsToFloat(R12i.w)) + intBitsToFloat(R2i.y)));
+R123i.x = clampFI32(R123i.x);
+PV0i.x = R123i.x;
+R126i.y = floatBitsToInt(intBitsToFloat(R6i.w) + intBitsToFloat(R2i.z));
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(uf_remappedPS[4].x),intBitsToFloat(R14i.y)) + intBitsToFloat(uf_remappedPS[5].x)));
+PV0i.z = R123i.z;
+R126i.w = floatBitsToInt(intBitsToFloat(R16i.y) + intBitsToFloat(R12i.w));
+PS0i = floatBitsToInt(sqrt(intBitsToFloat(R12i.z)));
+// 1
+R127i.x = floatBitsToInt(-(intBitsToFloat(R8i.z)) + -(intBitsToFloat(PV0i.z)));
+R125i.y = floatBitsToInt((intBitsToFloat(R4i.y) * intBitsToFloat(0x40008102) + intBitsToFloat(0xbf810204)));
+PV1i.z = floatBitsToInt(-(intBitsToFloat(R6i.x)) + intBitsToFloat(R9i.x));
+PV1i.w = floatBitsToInt(-(intBitsToFloat(PV0i.x)) + 1.0);
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(PS0i));
+// 2
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R8i.x), intBitsToFloat(PS1i)));
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R8i.y), intBitsToFloat(PS1i)));
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R8i.z), intBitsToFloat(PS1i)));
+R125i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.z),intBitsToFloat(R14i.z)) + intBitsToFloat(R6i.x)));
+R127i.z = floatBitsToInt(sqrt(intBitsToFloat(PV1i.w)));
+PS0i = R127i.z;
+// 3
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R12i.x),intBitsToFloat(R1i.z),intBitsToFloat(R1i.w),intBitsToFloat(R12i.y)),vec4(intBitsToFloat(PV0i.x),intBitsToFloat(PV0i.y),intBitsToFloat(PV0i.z),intBitsToFloat(R2i.w))));
+tempi.x = clampFI32(tempi.x);
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R126i.x = uf_remappedPS[13].w;
+PS1i = R126i.x;
+// 4
+R125i.x = uf_remappedPS[14].w;
+PV0i.y = floatBitsToInt(-(intBitsToFloat(R6i.y)) + intBitsToFloat(R9i.y));
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R6i.z)) + intBitsToFloat(R9i.z));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(uf_remappedPS[15].z),-(intBitsToFloat(PV1i.x))) + intBitsToFloat(uf_remappedPS[15].z)));
+PV0i.w = R123i.w;
+R124i.w = floatBitsToInt(-(intBitsToFloat(R7i.w)) + intBitsToFloat(R10i.w));
+PS0i = R124i.w;
+// 5
+backupReg0i = R127i.x;
+backupReg0i = R127i.x;
+R127i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.y),intBitsToFloat(R14i.z)) + intBitsToFloat(R6i.y)));
+R123i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(backupReg0i)),intBitsToFloat(PV0i.w)) + -(intBitsToFloat(backupReg0i))));
+PV1i.y = R123i.y;
+R125i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.z),intBitsToFloat(R14i.z)) + intBitsToFloat(R6i.z)));
+PV1i.w = floatBitsToInt(intBitsToFloat(R16i.x) * intBitsToFloat(0x437f0000));
+R10i.w = floatBitsToInt(intBitsToFloat(uf_remappedPS[16].z) * intBitsToFloat(0x437f0000));
+PS1i = R10i.w;
+// 6
+backupReg0i = R126i.x;
+R126i.x = floatBitsToInt(intBitsToFloat(R5i.w) + intBitsToFloat(PV1i.y));
+R127i.y = floatBitsToInt(intBitsToFloat(backupReg0i) + intBitsToFloat(PV1i.y));
+PV0i.z = floatBitsToInt(intBitsToFloat(R16i.z) + intBitsToFloat(PV1i.y));
+R127i.w = floatBitsToInt(intBitsToFloat(R17i.z) + intBitsToFloat(PV1i.y));
+R124i.y = int(uint(intBitsToFloat(PV1i.w)));
+PS0i = R124i.y;
+// 7
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R126i.y),intBitsToFloat(R126i.w),intBitsToFloat(R127i.z),-0.0),vec4(intBitsToFloat(R126i.y),intBitsToFloat(R126i.w),intBitsToFloat(R127i.z),0.0)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R126i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R18i.z), intBitsToFloat(PV0i.z)));
+R126i.z = clampFI32(R126i.z);
+PS1i = R126i.z;
+// 8
+backupReg0i = R126i.x;
+backupReg1i = R11i.y;
+R126i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R8i.w), intBitsToFloat(backupReg0i)));
+R126i.x = clampFI32(R126i.x);
+R11i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.x), intBitsToFloat(R127i.y)));
+R11i.y = clampFI32(R11i.y);
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(uf_remappedPS[17].z), intBitsToFloat(PS1i)));
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg1i), intBitsToFloat(R127i.w)));
+PV0i.w = clampFI32(PV0i.w);
+tempResultf = 1.0 / sqrt(intBitsToFloat(PV1i.x));
+PS0i = floatBitsToInt(tempResultf);
+// 9
+PV1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.z), intBitsToFloat(PS0i)));
+R123i.y = floatBitsToInt((intBitsToFloat(R19i.z) * intBitsToFloat(0x41200000) + intBitsToFloat(PV0i.z)));
+PV1i.y = R123i.y;
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.w), intBitsToFloat(PS0i)));
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.y), intBitsToFloat(PS0i)));
+R126i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R3i.w),-(intBitsToFloat(PV0i.w))) + intBitsToFloat(R3i.w)));
+PS1i = R126i.y;
+// 10
+backupReg0i = R0i.z;
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.y)));
+PV0i.x = clampFI32(PV0i.x);
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R9i.w), intBitsToFloat(PV1i.w)));
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R4i.z), intBitsToFloat(PV1i.x)));
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), intBitsToFloat(PV1i.z)));
+PS0i = floatBitsToInt(-(intBitsToFloat(R126i.x)) + 1.0);
+// 11
+backupReg0i = R126i.y;
+R126i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(uf_remappedPS[18].x),intBitsToFloat(R2i.x)) + intBitsToFloat(PV0i.y)));
+PV1i.x = R126i.x;
+R126i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(uf_remappedPS[18].x),intBitsToFloat(R125i.y)) + intBitsToFloat(PV0i.w)));
+PV1i.y = R126i.y;
+R127i.z = PV0i.z;
+PV1i.z = R127i.z;
+R127i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.y),intBitsToFloat(PV0i.x)) + intBitsToFloat(backupReg0i)));
+R127i.w = clampFI32(R127i.w);
+R126i.w = floatBitsToInt(intBitsToFloat(PV0i.x) + intBitsToFloat(PS0i));
+PS1i = R126i.w;
+// 12
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(PV1i.x),intBitsToFloat(PV1i.y),intBitsToFloat(PV1i.z),-0.0),vec4(intBitsToFloat(PV1i.x),intBitsToFloat(PV1i.y),intBitsToFloat(PV1i.z),0.0)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+tempResultf = log2(intBitsToFloat(R126i.z));
+if( isinf(tempResultf) == true ) tempResultf = -3.40282347E+38F;
+PS0i = floatBitsToInt(tempResultf);
+// 13
+backupReg0i = R125i.z;
+backupReg1i = R127i.w;
+PV1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(uf_remappedPS[15].w), intBitsToFloat(PS0i)));
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R125i.w),intBitsToFloat(R126i.w)) + intBitsToFloat(R127i.w)));
+R123i.y = clampFI32(R123i.y);
+PV1i.y = R123i.y;
+R125i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.x),intBitsToFloat(R126i.w)) + intBitsToFloat(R127i.w)));
+R125i.z = clampFI32(R125i.z);
+R127i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(backupReg0i),intBitsToFloat(R126i.w)) + intBitsToFloat(backupReg1i)));
+R127i.w = clampFI32(R127i.w);
+tempResultf = 1.0 / sqrt(intBitsToFloat(PV0i.x));
+R126i.z = floatBitsToInt(tempResultf);
+PS1i = R126i.z;
+// 14
+backupReg0i = R126i.x;
+R126i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), intBitsToFloat(PS1i)));
+PV0i.x = R126i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R124i.w),intBitsToFloat(PV1i.y)) + intBitsToFloat(R7i.w)));
+PV0i.y = R123i.y;
+R0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.z), intBitsToFloat(PV1i.y)));
+R124i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.y), intBitsToFloat(PS1i)));
+R125i.w = floatBitsToInt(exp2(intBitsToFloat(PV1i.x)));
+R125i.w = clampFI32(R125i.w);
+PS0i = R125i.w;
+// 15
+R125i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R7i.z), intBitsToFloat(PS0i)));
+R126i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R7i.x), intBitsToFloat(PS0i)));
+PV1i.y = R126i.y;
+R7i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R7i.y), intBitsToFloat(PS0i)));
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(uf_remappedPS[19].y), intBitsToFloat(PV0i.x)));
+R124i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R11i.y), intBitsToFloat(PV0i.y)));
+R124i.z = clampFI32(R124i.z);
+PS1i = R124i.z;
+// 16
+R127i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.z), intBitsToFloat(R125i.z)));
+R125i.y = floatBitsToInt(intBitsToFloat(R124i.w) + intBitsToFloat(PV1i.w));
+R125i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.z), intBitsToFloat(R127i.w)));
+R127i.w = floatBitsToInt(intBitsToFloat(R3i.x) + -(intBitsToFloat(PV1i.y)));
+PS0i = int(uint(intBitsToFloat(R10i.w)));
+// 17
+PV1i.x = R124i.y | PS0i;
+R124i.y = floatBitsToInt(intBitsToFloat(R3i.z) + -(intBitsToFloat(R125i.x)));
+R3i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(uf_remappedPS[19].x), intBitsToFloat(R126i.x)));
+R124i.w = floatBitsToInt(intBitsToFloat(R3i.y) + -(intBitsToFloat(R7i.z)));
+R126i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(uf_remappedPS[19].z), intBitsToFloat(R126i.x)));
+PS1i = R126i.w;
+// 18
+R126i.x = floatBitsToInt(intBitsToFloat(R124i.z) * intBitsToFloat(0x427f0000));
+R127i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.z), intBitsToFloat(R126i.z)));
+PV0i.y = R127i.y;
+R5i.z = 0x3db0b0b1;
+R5i.w = 0x3f800000;
+R127i.z = floatBitsToInt(float(uint(PV1i.x)));
+PS0i = R127i.z;
+// 19
+backupReg0i = R126i.y;
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R124i.w),intBitsToFloat(R127i.x)) + intBitsToFloat(R7i.z)));
+PV1i.x = R123i.x;
+R126i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(uf_remappedPS[10].y),intBitsToFloat(PV0i.y)) + intBitsToFloat(R125i.y))/2.0);
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.w),intBitsToFloat(R0i.z)) + intBitsToFloat(backupReg0i)));
+PV1i.z = R123i.z;
+R127i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R124i.y),intBitsToFloat(R125i.z)) + intBitsToFloat(R125i.x)));
+R125i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(uf_remappedPS[10].z),intBitsToFloat(PV0i.y)) + intBitsToFloat(R126i.w))/2.0);
+PS1i = R125i.y;
+// 20
+backupReg0i = R126i.x;
+R126i.x = floatBitsToInt(floor(intBitsToFloat(backupReg0i)));
+R126i.x = floatBitsToInt(intBitsToFloat(R126i.x) * 4.0);
+R0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R11i.y), intBitsToFloat(PV1i.x)));
+R125i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(uf_remappedPS[10].x),intBitsToFloat(R127i.y)) + intBitsToFloat(R3i.z))/2.0);
+R3i.w = 0x3f800000;
+R0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R11i.y), intBitsToFloat(PV1i.z)));
+PS0i = R0i.x;
+// 21
+R3i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R15i.x),-(intBitsToFloat(R125i.w))) + intBitsToFloat(R15i.x)));
+R3i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R15i.y),-(intBitsToFloat(R125i.w))) + intBitsToFloat(R15i.y)));
+R0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R11i.y), intBitsToFloat(R127i.w)));
+R0i.w = 0x3b808081;
+R3i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R15i.z),-(intBitsToFloat(R125i.w))) + intBitsToFloat(R15i.z)));
+PS1i = R3i.z;
+// 22
+R11i.x = floatBitsToInt(intBitsToFloat(R125i.z) + 0.5);
+R5i.y = floatBitsToInt(intBitsToFloat(R127i.z) * intBitsToFloat(0x3b808081));
+R11i.z = floatBitsToInt(intBitsToFloat(R125i.y) + 0.5);
+R11i.w = floatBitsToInt(intBitsToFloat(R126i.x) * intBitsToFloat(0x3b808081));
+R11i.y = floatBitsToInt(intBitsToFloat(R126i.y) + 0.5);
+PS0i = R11i.y;
+// 0
+R4i.xyz = ivec3(R3i.x,R3i.y,R3i.z);
+R4i.w = R3i.w;
+// 1
+R3i.xyz = ivec3(R11i.x,R11i.y,R11i.z);
+R3i.w = R11i.w;
+// 2
+R2i.xyz = ivec3(R0i.x,R0i.y,R0i.z);
+R2i.w = R0i.w;
+// 3
+R1i.xyz = ivec3(R5i.z,R5i.y,R5i.z);
+R1i.w = R5i.w;
+// export
+passPixelColor0 = vec4(intBitsToFloat(R1i.x), intBitsToFloat(R1i.y), intBitsToFloat(R1i.z), intBitsToFloat(R1i.w));
+passPixelColor1 = vec4(intBitsToFloat(R2i.x), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w));
+passPixelColor3 = vec4(intBitsToFloat(R3i.x), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.w));
+passPixelColor5 = vec4(intBitsToFloat(R4i.x), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w));
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/a5b3a5e5ab2938bc_0000000000001e49_ps.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/a5b3a5e5ab2938bc_0000000000001e49_ps.txt
@@ -1,0 +1,127 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader a5b3a5e5ab2938bc
+// Used for: Restoring the native BotW Anti-Aliasing implementation
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 1, binding = 3) uniform ufBlock
+{
+uniform ivec4 uf_remappedPS[3];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[3];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
+TEXTURE_LAYOUT(2, 1, 2) uniform sampler2D textureUnitPS2;
+layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
+layout(location = 0) out vec4 passPixelColor0;
+// uf_fragCoordScale was moved to the ufBlock
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R2f = vec4(0.0);
+vec4 R123f = vec4(0.0);
+vec4 R125f = vec4(0.0);
+vec4 R126f = vec4(0.0);
+vec4 R127f = vec4(0.0);
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = passParameterSem0;
+R1f = passParameterSem1;
+R2f.w = (texture(textureUnitPS1, R0f.xy).x);
+R0f.xyzw = (textureGather(textureUnitPS2, R0f.xy).xyzw);
+// 0
+backupReg0f = R0f.y;
+backupReg1f = R0f.x;
+PV0f.x = -(R2f.w) + R0f.w;
+PV0f.y = -(R2f.w) + R0f.z;
+PV0f.z = -(R2f.w) + backupReg0f;
+PV0f.w = -(R2f.w) + backupReg1f;
+PS0f = R2f.w + intBitsToFloat(uf_remappedPS[0].x);
+// 1
+R127f.x = max(PV0f.w, -(PV0f.w));
+PV1f.y = max(PV0f.z, -(PV0f.z));
+R127f.z = max(PV0f.y, -(PV0f.y));
+R127f.w = max(PV0f.x, -(PV0f.x));
+PS1f = 1.0 / PS0f;
+// 2
+R126f.x = intBitsToFloat(uf_remappedPS[1].w) * PS1f;
+R127f.y = PV1f.y * -(1.0);
+R126f.z = floor(R1f.y);
+R125f.w = floor(R1f.x);
+PV0f.w = R125f.w;
+PS0f = PV1f.y * -(1.0);
+// 3
+tempf.x = dot(vec4(R127f.w,R127f.z,R127f.x,PS0f),vec4(1.0,-(1.0),1.0,1.0));
+PV1f.x = tempf.x;
+PV1f.y = tempf.x;
+PV1f.z = tempf.x;
+PV1f.w = tempf.x;
+R126f.w = tempf.x;
+R126f.y = R1f.x + -(PV0f.w);
+PS1f = R126f.y;
+// 4
+tempf.x = dot(vec4(R127f.w,R127f.x,R127f.z,R127f.y),vec4(1.0,-(1.0),1.0,1.0));
+PV0f.x = tempf.x;
+PV0f.y = tempf.x;
+PV0f.z = tempf.x;
+PV0f.w = tempf.x;
+PS0f = R1f.y + -(R126f.z);
+// 5
+R123f.x = (mul_nonIEEE(R126f.x,PV0f.x) + PS0f);
+R123f.x = clamp(R123f.x, 0.0, 1.0);
+PV1f.x = R123f.x;
+R123f.y = (mul_nonIEEE(R126f.x,R126f.w) + R126f.y);
+R123f.y = clamp(R123f.y, 0.0, 1.0);
+PV1f.y = R123f.y;
+// 6
+PV0f.z = R126f.z + PV1f.x;
+PV0f.w = R125f.w + PV1f.y;
+// 7
+R1f.x = (mul_nonIEEE(PV0f.w,intBitsToFloat(uf_remappedPS[2].z)/resXScale) + R1f.z);
+R1f.y = (mul_nonIEEE(PV0f.z,intBitsToFloat(uf_remappedPS[2].w)/resYScale) + R1f.w);
+R1f.xyzw = (texture(textureUnitPS0, R1f.xy).xyzw);
+// export
+passPixelColor0 = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/b4a729584b6188ea_0000000000001e49_ps.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/b4a729584b6188ea_0000000000001e49_ps.txt
@@ -1,0 +1,110 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader b4a729584b6188ea
+// Used for: Restoring the native BotW Anti-Aliasing implementation for distant trees
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 1, binding = 3) uniform ufBlock
+{
+uniform ivec4 uf_remappedPS[3];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[3];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
+TEXTURE_LAYOUT(2, 1, 2) uniform sampler2D textureUnitPS2;
+layout(location = 0) in vec4 passParameterSem0;
+layout(location = 0) out vec4 passPixelColor0;
+// uf_fragCoordScale was moved to the ufBlock
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R2f = vec4(0.0);
+vec4 R123f = vec4(0.0);
+vec4 R127f = vec4(0.0);
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = passParameterSem0;
+R2f.w = (texture(textureUnitPS1, R0f.xy).x);
+R1f.xyzw = (textureGather(textureUnitPS2, R0f.xy).xyzw);
+// 0
+PV0f.x = -(R2f.w) + R1f.y;
+PV0f.y = -(R2f.w) + R1f.x;
+PV0f.z = -(R2f.w) + R1f.w;
+PV0f.w = -(R2f.w) + R1f.z;
+PS0f = R2f.w + intBitsToFloat(uf_remappedPS[0].x);
+// 1
+PV1f.x = max(PV0f.x, -(PV0f.x));
+PV1f.y = max(PV0f.y, -(PV0f.y));
+PV1f.z = max(PV0f.z, -(PV0f.z));
+PV1f.w = max(PV0f.w, -(PV0f.w));
+PS1f = 1.0 / PS0f;
+// 2
+PV0f.x = PV1f.y + -(PV1f.w);
+PV0f.y = -(PV1f.x) + PV1f.z;
+R127f.z = intBitsToFloat(uf_remappedPS[1].w) * PS1f;
+R127f.w = fract(R0f.z);
+R127f.y = fract(R0f.w);
+PS0f = R127f.y;
+// 3
+PV1f.z = PV0f.y + -(PV0f.x);
+PV1f.w = PV0f.y + PV0f.x;
+// 4
+R123f.x = (mul_nonIEEE(R127f.z,PV1f.z) + R127f.y);
+R123f.x = clamp(R123f.x, 0.0, 1.0);
+PV0f.x = R123f.x;
+R123f.y = (mul_nonIEEE(R127f.z,PV1f.w) + R127f.w);
+R123f.y = clamp(R123f.y, 0.0, 1.0);
+PV0f.y = R123f.y;
+// 5
+PV1f.z = -(R127f.y) + PV0f.x;
+PV1f.w = -(R127f.w) + PV0f.y;
+// 6
+backupReg0f = R0f.x;
+backupReg1f = R0f.y;
+R0f.x = (mul_nonIEEE(PV1f.w,intBitsToFloat(uf_remappedPS[2].z) / resXScale) + backupReg0f);
+R0f.y = (mul_nonIEEE(PV1f.z,intBitsToFloat(uf_remappedPS[2].w) / resYScale) + backupReg1f);
+R0f.xyzw = (texture(textureUnitPS0, R0f.xy).xyzw);
+// export
+passPixelColor0 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/bb50d2ee4fa87bc2_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/bb50d2ee4fa87bc2_0000000000000000_vs.txt
@@ -1,0 +1,196 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader bb50d2ee4fa87bc2
+// Used for: Horizontal+Vertical Combat Targeting Blur
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 1) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+TEXTURE_LAYOUT(32, 0, 0) uniform sampler2D textureUnitVS0;
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 1) out vec4 passParameterSem2;
+layout(location = 0) out vec4 passParameterSem0;
+layout(location = 2) out vec4 passParameterSem6;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+ivec4 R0i = ivec4(0);
+ivec4 R1i = ivec4(0);
+ivec4 R2i = ivec4(0);
+ivec4 R3i = ivec4(0);
+ivec4 R4i = ivec4(0);
+ivec4 R123i = ivec4(0);
+ivec4 R125i = ivec4(0);
+ivec4 R126i = ivec4(0);
+ivec4 R127i = ivec4(0);
+uvec4 attrDecoder;
+int backupReg0i, backupReg1i, backupReg2i, backupReg3i, backupReg4i;
+ivec4 PV0i = ivec4(0), PV1i = ivec4(0);
+int PS0i = 0, PS1i = 0;
+ivec4 tempi = ivec4(0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0i = ivec4(gl_VertexID, 0, 0, gl_InstanceID);
+attrDecoder.xyzw = attrDataSem0.xyzw;
+attrDecoder = ((attrDecoder>>8)&0xFF)|((attrDecoder<<8)&0xFF00);
+attrDecoder.xyzw = floatBitsToInt(vec4(unpackHalf2x16(attrDecoder.x|(attrDecoder.y<<16)),unpackHalf2x16(attrDecoder.z|(attrDecoder.w<<16))));
+R1i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder.x = attrDataSem1.x;
+attrDecoder.x = (attrDecoder.x>>24)|((attrDecoder.x>>8)&0xFF00)|((attrDecoder.x<<8)&0xFF0000)|((attrDecoder.x<<24));
+attrDecoder.y = 0;
+attrDecoder.z = 0;
+attrDecoder.w = 0;
+attrDecoder.xyzw = uvec4((attrDecoder.x>>0)&0x3FF,(attrDecoder.x>>10)&0x3FF,(attrDecoder.x>>20)&0x3FF,(attrDecoder.x>>30)&0x3);
+if( (attrDecoder.x&0x200) != 0 ) attrDecoder.x |= 0xFFFFFC00;
+if( (attrDecoder.y&0x200) != 0 ) attrDecoder.y |= 0xFFFFFC00;
+if( (attrDecoder.z&0x200) != 0 ) attrDecoder.z |= 0xFFFFFC00;
+attrDecoder.x = floatBitsToUint(max(float(int(attrDecoder.x))/511.0,-1.0));
+attrDecoder.y = floatBitsToUint(max(float(int(attrDecoder.y))/511.0,-1.0));
+attrDecoder.z = floatBitsToUint(max(float(int(attrDecoder.z))/511.0,-1.0));
+attrDecoder.w = floatBitsToUint(float(attrDecoder.w));
+R2i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+// 0
+backupReg0i = R0i.x;
+PV0i.x = 0x3f800000;
+PV0i.y = 0x40400000;
+PV0i.z = (backupReg0i == int(1))?int(0xFFFFFFFF):int(0x0);
+R127i.w = 0x3f800000;
+R127i.x = 0xbf800000;
+PS0i = R127i.x;
+// 1
+PV1i.x = floatBitsToInt(intBitsToFloat(uf_remappedVS[0].z) * intBitsToFloat(0x3b808081));
+R0i.y = 0;
+R123i.z = ((PV0i.z == 0)?(PV0i.x):(0xc0400000));
+PV1i.z = R123i.z;
+R123i.w = ((PV0i.z == 0)?(PV0i.y):(0xbf800000));
+PV1i.w = R123i.w;
+R2i.w = 0x3f800000;
+PS1i = R2i.w;
+// 2
+R2i.x = ((R0i.x == 0)?(R127i.x):(PV1i.w));
+PV0i.x = R2i.x;
+R2i.y = ((R0i.x == 0)?(R127i.w):(PV1i.z));
+PV0i.y = R2i.y;
+R2i.z = floatBitsToInt(intBitsToFloat(PV1i.x) + -(0.5));
+R2i.z = floatBitsToInt(intBitsToFloat(R2i.z) * 2.0);
+R0i.w = 0x3d2aaaab;
+R1i.x = 0x3e000000;
+PS0i = R1i.x;
+// 3
+R3i.x = uf_remappedVS[1].z;
+R3i.x = floatBitsToInt(intBitsToFloat(R3i.x) / 2.0);
+R1i.y = 0;
+R1i.z = floatBitsToInt(-(intBitsToFloat(PV0i.y)));
+R1i.w = floatBitsToInt(-(intBitsToFloat(uf_remappedVS[2].z)));
+R1i.w = floatBitsToInt(intBitsToFloat(R1i.w) / 2.0);
+R4i.x = floatBitsToInt((intBitsToFloat(PV0i.x) * 0.5 + 0.5));
+PS1i = R4i.x;
+R0i.w = floatBitsToInt(texture(textureUnitVS0, intBitsToFloat(R0i.wy)).x);
+R0i.xyz = floatBitsToInt(texture(textureUnitVS0, intBitsToFloat(R1i.xy)).xyz);
+// export
+SET_POSITION(vec4(intBitsToFloat(R2i.x), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w)));
+// export
+passParameterSem2 = vec4(intBitsToFloat(R0i.x), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
+// 0
+R127i.x = floatBitsToInt(intBitsToFloat(R3i.x) + -(0.5));
+R4i.y = floatBitsToInt((intBitsToFloat(R1i.z) * 0.5 + 0.5));
+PV0i.y = R4i.y;
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R2i.y)));
+PV0i.z = floatBitsToInt(intBitsToFloat(PV0i.z) / 2.0);
+PV0i.w = R2i.x;
+PV0i.w = floatBitsToInt(intBitsToFloat(PV0i.w) / 2.0);
+R126i.x = floatBitsToInt(intBitsToFloat(R1i.w) + -(0.5));
+PS0i = R126i.x;
+// 1
+R125i.x = uf_remappedVS[3].y;
+R125i.x = floatBitsToInt(intBitsToFloat(R125i.x) * 2.0);
+R126i.y = floatBitsToInt(-(intBitsToFloat(uf_remappedVS[3].x)));
+R126i.y = floatBitsToInt(intBitsToFloat(R126i.y) * 2.0);
+PV1i.y = R126i.y;
+R123i.z = floatBitsToInt((intBitsToFloat(uf_remappedVS[4].w) / resYScale * 2.0 + intBitsToFloat(PV0i.y)));
+PV1i.z = R123i.z;
+PV1i.w = floatBitsToInt(intBitsToFloat(PV0i.w) + intBitsToFloat(R3i.x));
+R127i.z = floatBitsToInt(intBitsToFloat(PV0i.z) + intBitsToFloat(R1i.w));
+PS1i = R127i.z;
+// 2
+PV0i.x = floatBitsToInt(intBitsToFloat(PV1i.z) + intBitsToFloat(R126i.x));
+PV0i.y = floatBitsToInt(intBitsToFloat(R4i.x) + intBitsToFloat(R127i.x));
+R126i.z = floatBitsToInt((-(intBitsToFloat(uf_remappedVS[4].w) / resYScale) * intBitsToFloat(0x3c23d70a) + intBitsToFloat(R4i.y)));
+R123i.w = floatBitsToInt((intBitsToFloat(uf_remappedVS[4].z) / resXScale  * 2.0 + intBitsToFloat(R4i.x)));
+PV0i.w = R123i.w;
+R127i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.y), intBitsToFloat(PV1i.w)));
+PS0i = R127i.y;
+// 3
+backupReg0i = R127i.x;
+R127i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.x), intBitsToFloat(R127i.z)));
+R123i.y = floatBitsToInt((-(intBitsToFloat(uf_remappedVS[4].z) / resXScale) * intBitsToFloat(0x3c23d70a) + intBitsToFloat(R4i.x)));
+PV1i.y = R123i.y;
+R127i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.y), intBitsToFloat(PV0i.y)));
+R127i.w = floatBitsToInt(intBitsToFloat(PV0i.w) + intBitsToFloat(backupReg0i));
+R125i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.x), intBitsToFloat(PV0i.x)));
+PS1i = R125i.z;
+// 4
+R3i.x = PV1i.y;
+PV0i.z = floatBitsToInt(intBitsToFloat(R4i.y) + intBitsToFloat(R126i.x));
+R3i.w = R126i.z;
+R4i.z = R127i.y;
+PS0i = R4i.z;
+// 5
+R1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.y), intBitsToFloat(R127i.w)));
+R1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.x), intBitsToFloat(PV0i.z)));
+R1i.z = R127i.z;
+R4i.w = R127i.x;
+R1i.w = R125i.z;
+PS1i = R1i.w;
+// export
+passParameterSem0 = vec4(intBitsToFloat(R4i.x), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w));
+// export
+// skipped export to semanticId 255
+// export
+passParameterSem6 = vec4(intBitsToFloat(R3i.x), intBitsToFloat(R3i.x), intBitsToFloat(R3i.x), intBitsToFloat(R3i.w));
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/c92c1c4c0a2fb839_0000000000001e49_ps.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/c92c1c4c0a2fb839_0000000000001e49_ps.txt
@@ -1,0 +1,182 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader c92c1c4c0a2fb839
+// Used for: Camera Depth of Field Blur
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 1, binding = 3) uniform ufBlock
+{
+uniform ivec4 uf_remappedPS[5];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[5];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
+TEXTURE_LAYOUT(2, 1, 2) uniform sampler2D textureUnitPS2;
+layout(location = 0) in vec4 passParameterSem2;
+layout(location = 0) out vec4 passPixelColor0;
+// uf_fragCoordScale was moved to the ufBlock
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+ivec4 R0i = ivec4(0);
+ivec4 R1i = ivec4(0);
+ivec4 R2i = ivec4(0);
+ivec4 R3i = ivec4(0);
+ivec4 R4i = ivec4(0);
+ivec4 R123i = ivec4(0);
+ivec4 R127i = ivec4(0);
+int backupReg0i, backupReg1i, backupReg2i, backupReg3i, backupReg4i;
+ivec4 PV0i = ivec4(0), PV1i = ivec4(0);
+int PS0i = 0, PS1i = 0;
+ivec4 tempi = ivec4(0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+bool activeMaskStack[2];
+bool activeMaskStackC[3];
+activeMaskStack[0] = false;
+activeMaskStackC[0] = false;
+activeMaskStackC[1] = false;
+activeMaskStack[0] = true;
+activeMaskStackC[0] = true;
+activeMaskStackC[1] = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0i = floatBitsToInt(passParameterSem2);
+if( activeMaskStackC[1] == true ) {
+R1i.w = floatBitsToInt(texture(textureUnitPS0, intBitsToFloat(R0i.xy)).x);
+R1i.z = floatBitsToInt(texture(textureUnitPS2, intBitsToFloat(R0i.xy)).x);
+}
+if( activeMaskStackC[1] == true ) {
+// 0
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R1i.w),intBitsToFloat(uf_remappedPS[0].x)) + intBitsToFloat(uf_remappedPS[1].x)));
+R123i.x = clampFI32(R123i.x);
+PV0i.x = R123i.x;
+// 1
+R0i.z = floatBitsToInt(max(intBitsToFloat(R1i.z), intBitsToFloat(PV0i.x)));
+PV1i.z = R0i.z;
+// 2
+R1i.y = ((intBitsToFloat(PV1i.z) != 0.0)?int(0xFFFFFFFF):int(0x0));
+PV0i.y = R1i.y;
+// 3
+if(  (PV0i.y == 0)) discard;
+}
+if( activeMaskStackC[1] == true ) {
+activeMaskStack[1] = activeMaskStack[0];
+activeMaskStackC[2] = activeMaskStackC[1];
+// 0
+predResult = (R1i.y != 0);
+activeMaskStack[1] = predResult;
+activeMaskStackC[2] = predResult == true && activeMaskStackC[1] == true;
+}
+else {
+activeMaskStack[1] = false;
+activeMaskStackC[2] = false;
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.w = floatBitsToInt(intBitsToFloat(uf_remappedPS[2].y) + -(1.0));
+// 1
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.w),intBitsToFloat(R0i.z)) + 1.0));
+PV1i.z = R123i.z;
+// 2
+tempResultf = log2(intBitsToFloat(PV1i.z));
+PS0i = floatBitsToInt(tempResultf);
+// 3
+R127i.x = floatBitsToInt(intBitsToFloat(PS0i) + -(1.0));
+PV1i.x = R127i.x;
+// 4
+R2i.z = PV1i.x;
+R1i.w = PV1i.x;
+PS0i = floatBitsToInt(exp2(intBitsToFloat(PV1i.x)));
+// 5
+PV1i.z = floatBitsToInt(intBitsToFloat(PS0i) + intBitsToFloat(uf_remappedPS[3].w));
+R3i.w = R127i.x;
+R4i.w = R127i.x;
+PS1i = R4i.w;
+// 6
+backupReg0i = R127i.x;
+R127i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.z), intBitsToFloat(uf_remappedPS[4].y)));
+PV0i.x = R127i.x;
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.z), intBitsToFloat(uf_remappedPS[4].x) / resXScale));
+R127i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.z), intBitsToFloat(uf_remappedPS[4].w) / resYScale));
+R127i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.z), intBitsToFloat(uf_remappedPS[4].z)));
+PV0i.w = R127i.w;
+R2i.w = floatBitsToInt(intBitsToFloat(backupReg0i) + 1.0);
+R2i.w = clampFI32(R2i.w);
+PS0i = R2i.w;
+// 7
+R1i.x = floatBitsToInt(intBitsToFloat(R0i.x) + intBitsToFloat(PV0i.y));
+R1i.y = floatBitsToInt(intBitsToFloat(R0i.y) + intBitsToFloat(PV0i.x));
+R3i.z = floatBitsToInt(intBitsToFloat(R0i.x) + intBitsToFloat(PV0i.w));
+R2i.x = floatBitsToInt(intBitsToFloat(R0i.x) + -(intBitsToFloat(PV0i.y)));
+PS1i = R2i.x;
+// 8
+R3i.x = floatBitsToInt(intBitsToFloat(R0i.y) + intBitsToFloat(R127i.z));
+R2i.y = floatBitsToInt(intBitsToFloat(R0i.y) + -(intBitsToFloat(R127i.x)));
+R4i.z = floatBitsToInt(intBitsToFloat(R0i.x) + -(intBitsToFloat(R127i.w)));
+R4i.y = floatBitsToInt(intBitsToFloat(R0i.y) + -(intBitsToFloat(R127i.z)));
+PS0i = R4i.y;
+}
+if( activeMaskStackC[2] == true ) {
+R1i.xyz = floatBitsToInt(textureLod(textureUnitPS1, intBitsToFloat(R1i.xy),intBitsToFloat(R1i.w)).xyz);
+R2i.xyz = floatBitsToInt(textureLod(textureUnitPS1, intBitsToFloat(R2i.xy),intBitsToFloat(R2i.z)).xyz);
+R3i.xyz = floatBitsToInt(textureLod(textureUnitPS1, intBitsToFloat(R3i.zx),intBitsToFloat(R3i.w)).xyz);
+R4i.xyz = floatBitsToInt(textureLod(textureUnitPS1, intBitsToFloat(R4i.zy),intBitsToFloat(R4i.w)).xyz);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.y = floatBitsToInt(intBitsToFloat(R1i.z) + intBitsToFloat(R2i.z));
+PV0i.y = floatBitsToInt(intBitsToFloat(PV0i.y) / 2.0);
+PV0i.z = floatBitsToInt(intBitsToFloat(R1i.y) + intBitsToFloat(R2i.y));
+PV0i.z = floatBitsToInt(intBitsToFloat(PV0i.z) / 2.0);
+PV0i.w = floatBitsToInt(intBitsToFloat(R1i.x) + intBitsToFloat(R2i.x));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV0i.w) / 2.0);
+// 1
+R123i.x = floatBitsToInt((intBitsToFloat(R3i.x) * 0.5 + intBitsToFloat(PV0i.w)));
+PV1i.x = R123i.x;
+R123i.z = floatBitsToInt((intBitsToFloat(R3i.z) * 0.5 + intBitsToFloat(PV0i.y)));
+PV1i.z = R123i.z;
+R123i.w = floatBitsToInt((intBitsToFloat(R3i.y) * 0.5 + intBitsToFloat(PV0i.z)));
+PV1i.w = R123i.w;
+// 2
+R2i.x = floatBitsToInt((intBitsToFloat(R4i.x) * 0.5 + intBitsToFloat(PV1i.x))/2.0);
+R2i.y = floatBitsToInt((intBitsToFloat(R4i.y) * 0.5 + intBitsToFloat(PV1i.w))/2.0);
+R2i.z = floatBitsToInt((intBitsToFloat(R4i.z) * 0.5 + intBitsToFloat(PV1i.z))/2.0);
+}
+activeMaskStackC[1] = activeMaskStack[0] == true && activeMaskStackC[0] == true;
+// export
+passPixelColor0 = vec4(intBitsToFloat(R2i.x), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w));
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/c9f2fd37115b0ee1_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/c9f2fd37115b0ee1_0000000000000000_vs.txt
@@ -1,0 +1,223 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader c9f2fd37115b0ee1
+// Used for: Horizontal+Vertical Combat Targeting Blur
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 1) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+TEXTURE_LAYOUT(32, 0, 0) uniform sampler2D textureUnitVS0;
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 0) out vec4 passParameterSem0;
+layout(location = 1) out vec4 passParameterSem2;
+layout(location = 2) out vec4 passParameterSem6;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+ivec4 R0i = ivec4(0);
+ivec4 R1i = ivec4(0);
+ivec4 R2i = ivec4(0);
+ivec4 R3i = ivec4(0);
+ivec4 R4i = ivec4(0);
+ivec4 R5i = ivec4(0);
+ivec4 R123i = ivec4(0);
+ivec4 R124i = ivec4(0);
+ivec4 R125i = ivec4(0);
+ivec4 R126i = ivec4(0);
+ivec4 R127i = ivec4(0);
+uvec4 attrDecoder;
+int backupReg0i, backupReg1i, backupReg2i, backupReg3i, backupReg4i;
+ivec4 PV0i = ivec4(0), PV1i = ivec4(0);
+int PS0i = 0, PS1i = 0;
+ivec4 tempi = ivec4(0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0i = ivec4(gl_VertexID, 0, 0, gl_InstanceID);
+attrDecoder.xyzw = attrDataSem0.xyzw;
+attrDecoder = ((attrDecoder>>8)&0xFF)|((attrDecoder<<8)&0xFF00);
+attrDecoder.xyzw = floatBitsToInt(vec4(unpackHalf2x16(attrDecoder.x|(attrDecoder.y<<16)),unpackHalf2x16(attrDecoder.z|(attrDecoder.w<<16))));
+R1i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder.x = attrDataSem1.x;
+attrDecoder.x = (attrDecoder.x>>24)|((attrDecoder.x>>8)&0xFF00)|((attrDecoder.x<<8)&0xFF0000)|((attrDecoder.x<<24));
+attrDecoder.y = 0;
+attrDecoder.z = 0;
+attrDecoder.w = 0;
+attrDecoder.xyzw = uvec4((attrDecoder.x>>0)&0x3FF,(attrDecoder.x>>10)&0x3FF,(attrDecoder.x>>20)&0x3FF,(attrDecoder.x>>30)&0x3);
+if( (attrDecoder.x&0x200) != 0 ) attrDecoder.x |= 0xFFFFFC00;
+if( (attrDecoder.y&0x200) != 0 ) attrDecoder.y |= 0xFFFFFC00;
+if( (attrDecoder.z&0x200) != 0 ) attrDecoder.z |= 0xFFFFFC00;
+attrDecoder.x = floatBitsToUint(max(float(int(attrDecoder.x))/511.0,-1.0));
+attrDecoder.y = floatBitsToUint(max(float(int(attrDecoder.y))/511.0,-1.0));
+attrDecoder.z = floatBitsToUint(max(float(int(attrDecoder.z))/511.0,-1.0));
+attrDecoder.w = floatBitsToUint(float(attrDecoder.w));
+R2i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+// 0
+backupReg0i = R0i.x;
+PV0i.x = 0x3f800000;
+PV0i.y = 0x40400000;
+PV0i.z = (backupReg0i == int(1))?int(0xFFFFFFFF):int(0x0);
+R127i.w = 0x3f800000;
+R127i.x = 0xbf800000;
+PS0i = R127i.x;
+// 1
+R3i.x = uf_remappedVS[0].z;
+R3i.x = floatBitsToInt(intBitsToFloat(R3i.x) / 2.0);
+PV1i.y = floatBitsToInt(intBitsToFloat(uf_remappedVS[1].z) * intBitsToFloat(0x3b808081));
+R123i.z = ((PV0i.z == 0)?(PV0i.x):(0xc0400000));
+PV1i.z = R123i.z;
+R123i.w = ((PV0i.z == 0)?(PV0i.y):(0xbf800000));
+PV1i.w = R123i.w;
+R2i.w = 0x3f800000;
+PS1i = R2i.w;
+// 2
+R2i.x = ((R0i.x == 0)?(R127i.x):(PV1i.w));
+R2i.y = ((R0i.x == 0)?(R127i.w):(PV1i.z));
+PV0i.y = R2i.y;
+R2i.z = floatBitsToInt(intBitsToFloat(PV1i.y) + -(0.5));
+R2i.z = floatBitsToInt(intBitsToFloat(R2i.z) * 2.0);
+R0i.w = 0x3ec00000;
+R0i.y = 0;
+PS0i = R0i.y;
+// 3
+R1i.xyz = ivec3(0x3eeaaaab,0,0x3d2aaaab);
+R1i.w = 0;
+R0i.x = floatBitsToInt(-(intBitsToFloat(PV0i.y)));
+PS1i = R0i.x;
+R5i.xyz = floatBitsToInt(texture(textureUnitVS0, intBitsToFloat(R0i.wy)).xyz);
+R4i.xyz = floatBitsToInt(texture(textureUnitVS0, intBitsToFloat(R1i.xy)).xyz);
+R1i.w = floatBitsToInt(texture(textureUnitVS0, intBitsToFloat(R1i.zw)).y);
+// export
+SET_POSITION(vec4(intBitsToFloat(R2i.x), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w)));
+// 0
+R127i.x = floatBitsToInt(-(intBitsToFloat(uf_remappedVS[2].z)));
+R127i.x = floatBitsToInt(intBitsToFloat(R127i.x) / 2.0);
+PV0i.x = R127i.x;
+R0i.y = floatBitsToInt((intBitsToFloat(R0i.x) * 0.5 + 0.5));
+PV0i.y = R0i.y;
+R127i.z = floatBitsToInt(-(intBitsToFloat(R2i.y)));
+R127i.z = floatBitsToInt(intBitsToFloat(R127i.z) / 2.0);
+R127i.w = R2i.x;
+R127i.w = floatBitsToInt(intBitsToFloat(R127i.w) / 2.0);
+R0i.x = floatBitsToInt((intBitsToFloat(R2i.x) * 0.5 + 0.5));
+PS0i = R0i.x;
+// 1
+R2i.x = floatBitsToInt(-(intBitsToFloat(uf_remappedVS[3].x)));
+R2i.x = floatBitsToInt(intBitsToFloat(R2i.x) * 2.0);
+PV1i.x = R2i.x;
+R2i.y = uf_remappedVS[3].y;
+R2i.y = floatBitsToInt(intBitsToFloat(R2i.y) * 2.0);
+PV1i.y = R2i.y;
+R123i.z = floatBitsToInt((intBitsToFloat(uf_remappedVS[4].w) / resYScale * 2.0 + intBitsToFloat(PV0i.y)));
+PV1i.z = R123i.z;
+R126i.w = floatBitsToInt(intBitsToFloat(R3i.x) + -(0.5));
+R125i.x = floatBitsToInt(intBitsToFloat(PV0i.x) + -(0.5));
+PS1i = R125i.x;
+// 2
+backupReg0i = R127i.z;
+R126i.x = floatBitsToInt(-(intBitsToFloat(PV1i.y)));
+R126i.x = floatBitsToInt(intBitsToFloat(R126i.x) / 2.0);
+PV0i.y = floatBitsToInt(-(intBitsToFloat(PV1i.x)));
+PV0i.y = floatBitsToInt(intBitsToFloat(PV0i.y) / 2.0);
+R127i.z = floatBitsToInt(intBitsToFloat(R127i.w) + intBitsToFloat(R3i.x));
+R127i.w = floatBitsToInt(intBitsToFloat(backupReg0i) + intBitsToFloat(R127i.x));
+R126i.z = floatBitsToInt(intBitsToFloat(PV1i.z) + intBitsToFloat(PS1i));
+PS0i = R126i.z;
+// 3
+R124i.x = floatBitsToInt(intBitsToFloat(R0i.x) + intBitsToFloat(R126i.w));
+R127i.y = floatBitsToInt((-(intBitsToFloat(uf_remappedVS[4].z)/resXScale) * intBitsToFloat(0x3c23d70a) + intBitsToFloat(R0i.x)));
+R125i.z = floatBitsToInt((-(intBitsToFloat(uf_remappedVS[4].w)/resYScale) * intBitsToFloat(0x3c23d70a) + intBitsToFloat(R0i.y)));
+R123i.w = floatBitsToInt((intBitsToFloat(uf_remappedVS[4].z)/ resXScale * 2.0 + intBitsToFloat(R0i.x)));
+PV1i.w = R123i.w;
+R125i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R2i.x),intBitsToFloat(R3i.x)) + intBitsToFloat(PV0i.y)));
+PS1i = R125i.w;
+// 4
+backupReg0i = R127i.x;
+R127i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.y), intBitsToFloat(R127i.w)));
+R126i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.x), intBitsToFloat(R127i.z)));
+R127i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R2i.y),intBitsToFloat(backupReg0i)) + intBitsToFloat(R126i.x)));
+R127i.w = floatBitsToInt(intBitsToFloat(PV1i.w) + intBitsToFloat(R126i.w));
+R124i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.y), intBitsToFloat(R126i.z)));
+PS0i = R124i.w;
+// 5
+backupReg0i = R0i.y;
+backupReg1i = R125i.z;
+PV1i.x = floatBitsToInt(-(intBitsToFloat(R5i.z)) + intBitsToFloat(R4i.z));
+PV1i.y = floatBitsToInt(-(intBitsToFloat(R5i.y)) + intBitsToFloat(R4i.y));
+R125i.z = floatBitsToInt(intBitsToFloat(backupReg0i) + intBitsToFloat(R125i.x));
+R126i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.x), intBitsToFloat(R124i.x)));
+R3i.w = backupReg1i;
+PS1i = R3i.w;
+// 6
+R3i.x = R127i.y;
+R1i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.y),intBitsToFloat(R0i.y)) + intBitsToFloat(R5i.y)));
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R5i.x)) + intBitsToFloat(R4i.x));
+R2i.w = R127i.z;
+R1i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.x),intBitsToFloat(R0i.y)) + intBitsToFloat(R5i.z)));
+PS0i = R1i.z;
+// 7
+R1i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.z),intBitsToFloat(R0i.y)) + intBitsToFloat(R5i.x)));
+R5i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.y), intBitsToFloat(R125i.z)));
+R2i.z = R125i.w;
+R0i.w = R127i.x;
+R0i.z = R126i.y;
+PS1i = R0i.z;
+// 8
+R5i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.x), intBitsToFloat(R127i.w)));
+R5i.z = R126i.w;
+R5i.w = R124i.w;
+// export
+passParameterSem0 = vec4(intBitsToFloat(R0i.x), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
+// export
+passParameterSem2 = vec4(intBitsToFloat(R1i.x), intBitsToFloat(R1i.y), intBitsToFloat(R1i.z), intBitsToFloat(R1i.w));
+// export
+// skipped export to semanticId 255
+// export
+// skipped export to semanticId 255
+// export
+passParameterSem6 = vec4(intBitsToFloat(R3i.x), intBitsToFloat(R3i.x), intBitsToFloat(R3i.x), intBitsToFloat(R3i.w));
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/cb0e6e8cbec4502a_0000000000000079_ps.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/cb0e6e8cbec4502a_0000000000000079_ps.txt
@@ -1,0 +1,53 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+
+// shader cb0e6e8cbec4502a 
+// Used for: 1 pass Battle, Camera and Scope Depth of Field Blur
+
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+layout(location = 0) in vec4 passParameterSem3;
+layout(location = 0) out vec4 passPixelColor0;
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform vec2 uf_fragCoordScale;
+#endif
+
+int radius = int( roundEven(2.0/uf_fragCoordScale.y) );
+vec2 resolution = vec2( textureSize(textureUnitPS0,0) );
+
+void main() {
+	vec2 center = ( passParameterSem3.xy + passParameterSem3.zw ) / 2.0 ;
+	vec3 result = vec3(0.0);
+	float count = 0.0;
+	for ( int x = 1-radius; x <= radius-1; x+=2 ) {
+		for ( int y = 1-radius; y <= radius-1; y+=2 ) {
+			if ( length(vec2(x, y)) <= radius ) {
+				result += texture( textureUnitPS0, center + vec2(x, y)/resolution ).xyz ;
+				count += 1.0;
+			}
+		}
+	}
+	passPixelColor0 = vec4( result / count, 0.0 );
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/d1cf6920c3d5b194_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/d1cf6920c3d5b194_0000000000000000_vs.txt
@@ -1,0 +1,98 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader d1cf6920c3d5b194
+// Used for: Restoring the native BotW Anti-Aliasing implementation for distant trees
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 0) out vec4 passParameterSem0;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R1f = vec4(0.0);
+vec4 R2f = vec4(0.0);
+vec4 R122f = vec4(0.0);
+vec4 R123f = vec4(0.0);
+uvec4 attrDecoder;
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R1f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(floatBitsToInt(1.0)));
+attrDecoder.xy = attrDataSem1.xy;
+attrDecoder.xy = (attrDecoder.xy>>24)|((attrDecoder.xy>>8)&0xFF00)|((attrDecoder.xy<<8)&0xFF0000)|((attrDecoder.xy<<24));
+attrDecoder.z = 0;
+attrDecoder.w = 0;
+R2f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(floatBitsToInt(0.0)), intBitsToFloat(floatBitsToInt(1.0)));
+// 0
+backupReg0f = R1f.x;
+backupReg1f = R1f.y;
+R1f.x = backupReg0f;
+R1f.x *= 2.0;
+R1f.y = backupReg1f;
+R1f.y *= 2.0;
+R1f.z = 1.0;
+R123f.w = (mul_nonIEEE(R2f.x,intBitsToFloat(uf_remappedVS[0].x) * resXScale) + 0.5);
+PV0f.w = R123f.w;
+R122f.x = (mul_nonIEEE(R2f.y,intBitsToFloat(uf_remappedVS[0].y) * resYScale) + 0.5);
+PS0f = R122f.x;
+// 1
+R2f.z = PV0f.w;
+R2f.w = PS0f;
+// export
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.z));
+// export
+passParameterSem0 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/e06e20b2efe87a84_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/e06e20b2efe87a84_0000000000000000_vs.txt
@@ -1,0 +1,106 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader e06e20b2efe87a84
+// Used for: Horizontal Ambient-Occlusion Blur
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 0) out vec4 passParameterSem0;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R2f = vec4(0.0);
+uvec4 attrDecoder;
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = floatBitsToInt(ivec4(gl_VertexID, 0, 0, gl_InstanceID));
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R1f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(floatBitsToInt(1.0)));
+attrDecoder.xy = attrDataSem1.xy;
+attrDecoder.xy = (attrDecoder.xy>>24)|((attrDecoder.xy>>8)&0xFF00)|((attrDecoder.xy<<8)&0xFF0000)|((attrDecoder.xy<<24));
+attrDecoder.z = 0;
+attrDecoder.w = 0;
+R2f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(floatBitsToInt(0.0)), intBitsToFloat(floatBitsToInt(1.0)));
+// 0
+backupReg0f = R1f.x;
+backupReg1f = R1f.y;
+R1f.x = backupReg0f;
+R1f.x *= 2.0;
+R1f.y = backupReg1f;
+R1f.y *= 2.0;
+R1f.z = -(1.0);
+R1f.w = 1.0;
+R0f.x = R2f.x;
+PS0f = R0f.x;
+// 1
+backupReg0f = R2f.x;
+backupReg0f = R2f.x;
+backupReg0f = R2f.x;
+R2f.x = R2f.y;
+R0f.y = R2f.y;
+R2f.z = backupReg0f + intBitsToFloat(uf_remappedVS[0].x)/resXScale;
+R2f.w = backupReg0f;
+R2f.y = backupReg0f + -(intBitsToFloat(uf_remappedVS[0].x))/resXScale;
+PS1f = R2f.y;
+// export
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
+// export
+passParameterSem0 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
+// export
+// skipped export to semanticId 255
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/ea9a49a6185cf1e5_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/ea9a49a6185cf1e5_0000000000000000_vs.txt
@@ -1,0 +1,131 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader ea9a49a6185cf1e5
+// Used for: Fix Reflection
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[2];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[2];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 0) noperspective out vec4 passParameterSem0;
+layout(location = 1) noperspective out vec4 passParameterSem1;
+layout(location = 2) noperspective out vec4 passParameterSem2;
+layout(location = 3) noperspective out vec4 passParameterSem3;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R2f = vec4(0.0);
+vec4 R3f = vec4(0.0);
+vec4 R123f = vec4(0.0);
+vec4 R126f = vec4(0.0);
+vec4 R127f = vec4(0.0);
+uvec4 attrDecoder;
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = floatBitsToInt(ivec4(gl_VertexID, 0, 0, gl_InstanceID));
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R1f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(floatBitsToInt(1.0)));
+// 0
+PV0f.x = (0.0 > R1f.y)?1.0:0.0;
+PV0f.y = (0.0 > R1f.x)?1.0:0.0;
+PV0f.z = (R1f.y > 0.0)?1.0:0.0;
+PV0f.w = (R1f.x > 0.0)?1.0:0.0;
+R1f.z = 0.0;
+PS0f = R1f.z;
+// 1
+R1f.x = PV0f.w + -(PV0f.y);
+PV1f.x = R1f.x;
+R1f.y = PV0f.z + -(PV0f.x);
+PV1f.y = R1f.y;
+R1f.w = 1.0;
+// 2
+PV0f.x = PV1f.x;
+PV0f.x /= 2.0;
+R127f.y = PV1f.x * 1.0;
+PV0f.y = R127f.y;
+PV0f.z = -(PV1f.y);
+PV0f.z /= 2.0;
+R127f.w = PV1f.y * -(1.0);
+PV0f.w = R127f.w;
+R127f.x = PV1f.x * 1.0;
+PS0f = R127f.x;
+// 3
+R126f.x = (intBitsToFloat(uf_remappedVS[0].y) * 2.0 / resYScale + PV0f.w);
+R0f.y = PV0f.z + 0.5;
+R123f.z = (intBitsToFloat(uf_remappedVS[0].x) * 2.0 / resXScale + PV0f.y);
+PV1f.z = R123f.z;
+PV1f.w = PV0f.w;
+R0f.x = PV0f.x + 0.5;
+PS1f = R0f.x;
+// 4
+R2f.x = (mul_nonIEEE(R127f.x,-(intBitsToFloat(uf_remappedVS[1].x))) + -(intBitsToFloat(uf_remappedVS[1].z)));
+R2f.y = (mul_nonIEEE(R127f.w,-(intBitsToFloat(uf_remappedVS[1].y))) + -(intBitsToFloat(uf_remappedVS[1].w)));
+R0f.z = (mul_nonIEEE(-(intBitsToFloat(uf_remappedVS[1].x)),PV1f.z) + -(intBitsToFloat(uf_remappedVS[1].z)));
+R0f.w = (mul_nonIEEE(-(intBitsToFloat(uf_remappedVS[1].y)),PV1f.w) + -(intBitsToFloat(uf_remappedVS[1].w)));
+R3f.x = (mul_nonIEEE(R127f.y,-(intBitsToFloat(uf_remappedVS[1].x))) + -(intBitsToFloat(uf_remappedVS[1].z)));
+PS0f = R3f.x;
+// 5
+R3f.y = (mul_nonIEEE(R126f.x,-(intBitsToFloat(uf_remappedVS[1].y))) + -(intBitsToFloat(uf_remappedVS[1].w)));
+// export
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
+// export
+passParameterSem0 = vec4(R0f.x, R0f.y, R0f.z, R0f.z);
+// export
+passParameterSem1 = vec4(R2f.x, R2f.y, R2f.z, R2f.z);
+// export
+passParameterSem2 = vec4(R0f.z, R0f.w, R0f.z, R0f.z);
+// export
+passParameterSem3 = vec4(R3f.x, R3f.y, R3f.z, R3f.z);
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/f14bb57cd5c9cb77_00000000000003c9_ps.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/f14bb57cd5c9cb77_00000000000003c9_ps.txt
@@ -1,0 +1,1096 @@
+#version 430
+#extension GL_ARB_texture_gather : enable
+#extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+
+// shader f14bb57cd5c9cb77 - dumped 1.15
+// Used for: Removing/Restoring the native BotW World Anti-Aliasing implementation
+
+const float resX = float($width)/float($gameWidth);
+const float resY = float($height)/float($gameHeight);
+#define fxaa $fxaa
+
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
+uniform ivec4 uf_remappedPS[4];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[4];
+uniform vec2 uf_fragCoordScale;
+#endif
+
+#if (fxaa == 0) // Disabled AA
+
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+layout(location = 0) in vec4 passParameterSem2;
+layout(location = 0) out vec4 passPixelColor0;
+void main()
+{
+passPixelColor0 = texture(textureUnitPS0, passParameterSem2.xy);
+}
+
+#elif (fxaa == 1) // Native AA Enabled
+
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
+layout(location = 0) in vec4 passParameterSem2;
+layout(location = 0) out vec4 passPixelColor0;
+// uf_fragCoordScale was moved to the ufBlock
+
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){return mix(0.0, a*b, (a != 0.0) && (b != 0.0));}
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0); // Important variable
+vec4 R2f = vec4(0.0);
+vec4 R3f = vec4(0.0); // Important variable
+vec4 R123f = vec4(0.0);
+vec4 R126f = vec4(0.0);
+vec4 R127f = vec4(0.0);
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+bool activeMaskStack[2];
+bool activeMaskStackC[3];
+activeMaskStack[0] = false;
+activeMaskStackC[0] = false;
+activeMaskStackC[1] = false;
+activeMaskStack[0] = true;
+activeMaskStackC[0] = true;
+activeMaskStackC[1] = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = passParameterSem2;
+if( activeMaskStackC[1] == true ) {
+R1f.xyzw = (textureGather(textureUnitPS1, R0f.xy).wzxy);
+R2f.xyzw = (texture(textureUnitPS0, R0f.xy).xyzw);
+}
+if( activeMaskStackC[1] == true ) {
+activeMaskStack[1] = activeMaskStack[0];
+activeMaskStackC[2] = activeMaskStackC[1];
+// 0
+PV0f.x = R1f.w + -(R1f.x); 
+PV0f.y = R1f.z + -(R1f.y);
+PV0f.z = mul_nonIEEE(R2f.x, intBitsToFloat(uf_remappedPS[0].x));
+R127f.w = min(R1f.z, R1f.x);
+R127f.x = min(R1f.w, R1f.y);
+PS0f = R127f.x;
+// 1
+R123f.x = (mul_nonIEEE(R2f.y,intBitsToFloat(uf_remappedPS[0].y) * resX ) + PV0f.z); //Important line
+PV1f.x = R123f.x;
+PV1f.y = max(R1f.z, R1f.x);
+R127f.z = PV0f.y + -(PV0f.x);
+PV1f.z = R127f.z;
+R126f.w = PV0f.y + PV0f.x;
+PV1f.w = R126f.w;
+PS1f = max(R1f.w, R1f.y);
+// 2
+PV0f.x = max(PV1f.z, -(PV1f.z));
+PV0f.y = max(PV1f.w, -(PV1f.w));
+R123f.z = (mul_nonIEEE(R2f.z,intBitsToFloat(uf_remappedPS[0].z)) + PV1f.x);
+PV0f.z = R123f.z;
+PV0f.w = min(R127f.w, R127f.x);
+PS0f = max(PV1f.y, PS1f);
+// 3
+PV1f.x = mul_nonIEEE(PS0f, intBitsToFloat(uf_remappedPS[1].x));
+PV1f.y = max(PV0f.z, PS0f);
+PV1f.z = min(PV0f.z, PV0f.w);
+PV1f.w = min(PV0f.y, PV0f.x);
+// 4
+R1f.x = -(PV1f.z) + PV1f.y;
+R0f.z = max(PV1f.x, intBitsToFloat(uf_remappedPS[1].y)); // Important - Divide looks blurrier/fuzzy and multiply looks sharper good
+PS0f = 1.0 / PV1f.w; 									// Important line affects aliasing strongly, increasing it  is blurier and decreasing sharpens
+// 5
+PV1f.x = mul_nonIEEE(R127f.z, PS0f);
+PV1f.y = mul_nonIEEE(R126f.w, PS0f);
+// 6
+PV0f.z = max(PV1f.x, -(intBitsToFloat(uf_remappedPS[2].y)));
+PV0f.w = max(PV1f.y, -(intBitsToFloat(uf_remappedPS[2].y)));
+// 7 - another way to do it other than the original implmentation
+R3f.x = min(PV0f.w, intBitsToFloat(uf_remappedPS[2].y)); // Important - Divide looks sharper and better and multiply looks blurier fuzzy
+R1f.y = min(PV0f.z, intBitsToFloat(uf_remappedPS[2].y)); // Important - Divide looks sharper and better and multiply looks blurier fuzzy
+// 8
+predResult = (R1f.x > R0f.z);
+activeMaskStack[1] = predResult;
+activeMaskStackC[2] = predResult == true && activeMaskStackC[1] == true;
+}
+else {
+activeMaskStack[1] = false;
+activeMaskStackC[2] = false;
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+backupReg0f = R3f.x;
+backupReg0f = R3f.x;
+R3f.x = (mul_nonIEEE(backupReg0f,intBitsToFloat(uf_remappedPS[3].x) / resX) + R0f.x); // Original Implementation
+R3f.y = (mul_nonIEEE(R1f.y,intBitsToFloat(uf_remappedPS[3].y) / resY) + R0f.y); // Original Implementation
+R1f.x = (mul_nonIEEE(backupReg0f,-(intBitsToFloat(uf_remappedPS[3].x) / resX)) + R0f.x); // Original Implementation
+PS0f = R1f.x;
+// 1
+backupReg0f = R1f.y;
+R1f.y = (mul_nonIEEE(backupReg0f,-(intBitsToFloat(uf_remappedPS[3].y) / resY)) + R0f.y); // Original Implementation
+}
+if( activeMaskStackC[2] == true ) {
+R0f.xyzw = (texture(textureUnitPS0, R3f.xy).xyzw);
+R1f.xyzw = (texture(textureUnitPS0, R1f.xy).xyzw);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+R127f.x = R0f.w + R1f.w;
+R127f.x /= 2.0;
+PV0f.x = R127f.x;
+R127f.y = R0f.z + R1f.z;
+R127f.y /= 2.0;
+PV0f.y = R127f.y;
+R127f.z = R0f.y + R1f.y;
+R127f.z /= 2.0;
+PV0f.z = R127f.z;
+R127f.w = R0f.x + R1f.x;
+R127f.w /= 2.0;
+PV0f.w = R127f.w;
+// 1
+PV1f.x = R2f.w + -(PV0f.x);
+PV1f.y = R2f.z + -(PV0f.y);
+PV1f.z = R2f.y + -(PV0f.z);
+PV1f.w = R2f.x + -(PV0f.w);
+// 2
+R2f.x = (PV1f.w * intBitsToFloat(0x3eb33333) + R127f.w);
+R2f.y = (PV1f.z * intBitsToFloat(0x3eb33333) + R127f.z);
+R2f.z = (PV1f.y * intBitsToFloat(0x3eb33333) + R127f.y);
+R2f.w = (PV1f.x * intBitsToFloat(0x3eb33333) + R127f.x);
+}
+activeMaskStackC[1] = activeMaskStack[0] == true && activeMaskStackC[0] == true;
+// export
+passPixelColor0 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
+}
+
+#elif (fxaa == 2)
+
+//-----------------------------settings-------------------------------------//
+
+#define Subpix               $subPix  //[0.000 to 1.000] Choose the amount of sub-pixel aliasing removal.
+#define EdgeThreshold        $edgeThreshold  //[0.000 to 1.000] Edge detection threshold. The minimum amount of local contrast required to apply algorithm.
+#define EdgeThresholdMin     $edgeThresholdMin  //[0.000 to 1.000] Darkness threshold. Trims the algorithm from processing darks.
+
+//--------------------------------------------------------------------------//
+
+#define FXAA_PC 1
+#define FXAA_GLSL_130 1
+#define FXAA_QUALITY_PRESET 39
+
+#define FXAA_GREEN_AS_LUMA 1
+#define FXAA_DISCARD 0
+#define FXAA_GATHER4_ALPHA 0 // Needs #extension GL_ARB_gpu_shader5 : enable
+
+/*--------------------------------------------------------------------------*/
+#ifndef FXAA_GLSL_120
+    #define FXAA_GLSL_120 0
+#endif
+/*--------------------------------------------------------------------------*/
+#ifndef FXAA_GLSL_130
+    #define FXAA_GLSL_130 0
+#endif
+/*--------------------------------------------------------------------------*/
+
+
+/*==========================================================================*/
+#ifndef FXAA_GREEN_AS_LUMA
+    //
+    // For those using non-linear color,
+    // and either not able to get luma in alpha, or not wanting to,
+    // this enables FXAA to run using green as a proxy for luma.
+    // So with this enabled, no need to pack luma in alpha.
+    //
+    // This will turn off AA on anything which lacks some amount of green.
+    // Pure red and blue or combination of only R and B, will get no AA.
+    //
+    // Might want to lower the settings for both,
+    //    fxaaConsoleEdgeThresholdMin
+    //    fxaaQualityEdgeThresholdMin
+    // In order to insure AA does not get turned off on colors 
+    // which contain a minor amount of green.
+    //
+    // 1 = On.
+    // 0 = Off.
+    //
+    #define FXAA_GREEN_AS_LUMA 0
+#endif
+/*--------------------------------------------------------------------------*/
+#ifndef FXAA_EARLY_EXIT
+    //
+    // Controls algorithm's early exit path.
+    // On PS3 turning this ON adds 2 cycles to the shader.
+    // On 360 turning this OFF adds 10ths of a millisecond to the shader.
+    // Turning this off on console will result in a more blurry image.
+    // So this defaults to on.
+    //
+    // 1 = On.
+    // 0 = Off.
+    //
+    #define FXAA_EARLY_EXIT 1
+#endif
+/*--------------------------------------------------------------------------*/
+#ifndef FXAA_DISCARD
+    //
+    // Only valid for PC OpenGL currently.
+    // Probably will not work when FXAA_GREEN_AS_LUMA = 1.
+    //
+    // 1 = Use discard on pixels which don't need AA.
+    //     For APIs which enable concurrent TEX+ROP from same surface.
+    // 0 = Return unchanged color on pixels which don't need AA.
+    //
+    #define FXAA_DISCARD 0
+#endif
+/*--------------------------------------------------------------------------*/
+#ifndef FXAA_FAST_PIXEL_OFFSET
+    //
+    // Used for GLSL 120 only.
+    //
+    // 1 = GL API supports fast pixel offsets
+    // 0 = do not use fast pixel offsets
+    //
+    #ifdef GL_EXT_gpu_shader4
+        #define FXAA_FAST_PIXEL_OFFSET 1
+    #endif
+    #ifdef GL_NV_gpu_shader5
+        #define FXAA_FAST_PIXEL_OFFSET 1
+    #endif
+    #ifdef GL_ARB_gpu_shader5
+        #define FXAA_FAST_PIXEL_OFFSET 1
+    #endif
+    #ifndef FXAA_FAST_PIXEL_OFFSET
+        #define FXAA_FAST_PIXEL_OFFSET 0
+    #endif
+#endif
+/*--------------------------------------------------------------------------*/
+#ifndef FXAA_GATHER4_ALPHA
+    //
+    // 1 = API supports gather4 on alpha channel.
+    // 0 = API does not support gather4 on alpha channel.
+    //
+    #if (FXAA_HLSL_5 == 1)
+        #define FXAA_GATHER4_ALPHA 1
+    #endif
+    #ifdef GL_ARB_gpu_shader5
+        #define FXAA_GATHER4_ALPHA 1
+    #endif
+    #ifdef GL_NV_gpu_shader5
+        #define FXAA_GATHER4_ALPHA 1
+    #endif
+    #ifndef FXAA_GATHER4_ALPHA
+        #define FXAA_GATHER4_ALPHA 0
+    #endif
+#endif
+
+
+/*============================================================================
+                        FXAA QUALITY - TUNING KNOBS
+------------------------------------------------------------------------------
+NOTE the other tuning knobs are now in the shader function inputs!
+============================================================================*/
+#ifndef FXAA_QUALITY_PRESET
+    //
+    // Choose the quality preset.
+    // This needs to be compiled into the shader as it effects code.
+    // Best option to include multiple presets is to 
+    // in each shader define the preset, then include this file.
+    // 
+    // OPTIONS
+    // -----------------------------------------------------------------------
+    // 10 to 15 - default medium dither (10=fastest, 15=highest quality)
+    // 20 to 29 - less dither, more expensive (20=fastest, 29=highest quality)
+    // 39       - no dither, very expensive 
+    //
+    // NOTES
+    // -----------------------------------------------------------------------
+    // 12 = slightly faster then FXAA 3.9 and higher edge quality (default)
+    // 13 = about same speed as FXAA 3.9 and better than 12
+    // 23 = closest to FXAA 3.9 visually and performance wise
+    //  _ = the lowest digit is directly related to performance
+    // _  = the highest digit is directly related to style
+    // 
+    #define FXAA_QUALITY_PRESET 12
+#endif
+
+
+/*============================================================================
+
+                           FXAA QUALITY - PRESETS
+
+============================================================================*/
+
+/*============================================================================
+                     FXAA QUALITY - MEDIUM DITHER PRESETS
+============================================================================*/
+#if (FXAA_QUALITY_PRESET == 10)
+    #define FXAA_QUALITY_PS 3
+    #define FXAA_QUALITY_P0 1.5
+    #define FXAA_QUALITY_P1 3.0
+    #define FXAA_QUALITY_P2 12.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 11)
+    #define FXAA_QUALITY_PS 4
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 3.0
+    #define FXAA_QUALITY_P3 12.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 12)
+    #define FXAA_QUALITY_PS 5
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 4.0
+    #define FXAA_QUALITY_P4 12.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 13)
+    #define FXAA_QUALITY_PS 6
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 4.0
+    #define FXAA_QUALITY_P5 12.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 14)
+    #define FXAA_QUALITY_PS 7
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 2.0
+    #define FXAA_QUALITY_P5 4.0
+    #define FXAA_QUALITY_P6 12.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 15)
+    #define FXAA_QUALITY_PS 8
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 2.0
+    #define FXAA_QUALITY_P5 2.0
+    #define FXAA_QUALITY_P6 4.0
+    #define FXAA_QUALITY_P7 12.0
+#endif
+
+/*============================================================================
+                     FXAA QUALITY - LOW DITHER PRESETS
+============================================================================*/
+#if (FXAA_QUALITY_PRESET == 20)
+    #define FXAA_QUALITY_PS 3
+    #define FXAA_QUALITY_P0 1.5
+    #define FXAA_QUALITY_P1 2.0
+    #define FXAA_QUALITY_P2 8.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 21)
+    #define FXAA_QUALITY_PS 4
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 8.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 22)
+    #define FXAA_QUALITY_PS 5
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 8.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 23)
+    #define FXAA_QUALITY_PS 6
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 2.0
+    #define FXAA_QUALITY_P5 8.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 24)
+    #define FXAA_QUALITY_PS 7
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 2.0
+    #define FXAA_QUALITY_P5 3.0
+    #define FXAA_QUALITY_P6 8.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 25)
+    #define FXAA_QUALITY_PS 8
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 2.0
+    #define FXAA_QUALITY_P5 2.0
+    #define FXAA_QUALITY_P6 4.0
+    #define FXAA_QUALITY_P7 8.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 26)
+    #define FXAA_QUALITY_PS 9
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 2.0
+    #define FXAA_QUALITY_P5 2.0
+    #define FXAA_QUALITY_P6 2.0
+    #define FXAA_QUALITY_P7 4.0
+    #define FXAA_QUALITY_P8 8.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 27)
+    #define FXAA_QUALITY_PS 10
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 2.0
+    #define FXAA_QUALITY_P5 2.0
+    #define FXAA_QUALITY_P6 2.0
+    #define FXAA_QUALITY_P7 2.0
+    #define FXAA_QUALITY_P8 4.0
+    #define FXAA_QUALITY_P9 8.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 28)
+    #define FXAA_QUALITY_PS 11
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 2.0
+    #define FXAA_QUALITY_P5 2.0
+    #define FXAA_QUALITY_P6 2.0
+    #define FXAA_QUALITY_P7 2.0
+    #define FXAA_QUALITY_P8 2.0
+    #define FXAA_QUALITY_P9 4.0
+    #define FXAA_QUALITY_P10 8.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 29)
+    #define FXAA_QUALITY_PS 12
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 2.0
+    #define FXAA_QUALITY_P5 2.0
+    #define FXAA_QUALITY_P6 2.0
+    #define FXAA_QUALITY_P7 2.0
+    #define FXAA_QUALITY_P8 2.0
+    #define FXAA_QUALITY_P9 2.0
+    #define FXAA_QUALITY_P10 4.0
+    #define FXAA_QUALITY_P11 8.0
+#endif
+
+/*============================================================================
+                     FXAA QUALITY - EXTREME QUALITY
+============================================================================*/
+#if (FXAA_QUALITY_PRESET == 39)
+    #define FXAA_QUALITY_PS 12
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.0
+    #define FXAA_QUALITY_P2 1.0
+    #define FXAA_QUALITY_P3 1.0
+    #define FXAA_QUALITY_P4 1.0
+    #define FXAA_QUALITY_P5 1.5
+    #define FXAA_QUALITY_P6 2.0
+    #define FXAA_QUALITY_P7 2.0
+    #define FXAA_QUALITY_P8 2.0
+    #define FXAA_QUALITY_P9 2.0
+    #define FXAA_QUALITY_P10 4.0
+    #define FXAA_QUALITY_P11 8.0
+#endif
+
+
+
+/*============================================================================
+
+                                API PORTING
+
+============================================================================*/
+#if (FXAA_GLSL_120 == 1) || (FXAA_GLSL_130 == 1)
+    #define FxaaBool bool
+    #define FxaaDiscard discard
+    #define FxaaFloat float
+    #define FxaaFloat2 vec2
+    #define FxaaFloat3 vec3
+    #define FxaaFloat4 vec4
+    #define FxaaHalf float
+    #define FxaaHalf2 vec2
+    #define FxaaHalf3 vec3
+    #define FxaaHalf4 vec4
+    #define FxaaInt2 ivec2
+    #define FxaaSat(x) clamp(x, 0.0, 1.0)
+    #define FxaaTex sampler2D
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_GLSL_120 == 1)
+    // Requires,
+    //  #version 120
+    // And at least,
+    //  #extension GL_EXT_gpu_shader4 : enable
+    //  (or set FXAA_FAST_PIXEL_OFFSET 1 to work like DX9)
+    #define FxaaTexTop(t, p) texture2DLod(t, p, 0.0)
+    #if (FXAA_FAST_PIXEL_OFFSET == 1)
+        #define FxaaTexOff(t, p, o, r) texture2DLodOffset(t, p, 0.0, o)
+    #else
+        #define FxaaTexOff(t, p, o, r) texture2DLod(t, p + (o * r), 0.0)
+    #endif
+    #if (FXAA_GATHER4_ALPHA == 1)
+        // use #extension GL_ARB_gpu_shader5 : enable
+        #define FxaaTexAlpha4(t, p) textureGather(t, p, 3)
+        #define FxaaTexOffAlpha4(t, p, o) textureGatherOffset(t, p, o, 3)
+        #define FxaaTexGreen4(t, p) textureGather(t, p, 1)
+        #define FxaaTexOffGreen4(t, p, o) textureGatherOffset(t, p, o, 1)
+    #endif
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_GLSL_130 == 1)
+    // Requires "#version 130" or better
+    #define FxaaTexTop(t, p) textureLod(t, p, 0.0)
+    #define FxaaTexOff(t, p, o, r) textureLodOffset(t, p, 0.0, o)
+    #if (FXAA_GATHER4_ALPHA == 1)
+        // use #extension GL_ARB_gpu_shader5 : enable
+        #define FxaaTexAlpha4(t, p) textureGather(t, p, 3)
+        #define FxaaTexOffAlpha4(t, p, o) textureGatherOffset(t, p, o, 3)
+        #define FxaaTexGreen4(t, p) textureGather(t, p, 1)
+        #define FxaaTexOffGreen4(t, p, o) textureGatherOffset(t, p, o, 1)
+    #endif
+#endif
+/*--------------------------------------------------------------------------*/
+
+
+/*============================================================================
+                   GREEN AS LUMA OPTION SUPPORT FUNCTION
+============================================================================*/
+#if (FXAA_GREEN_AS_LUMA == 0)
+    FxaaFloat FxaaLuma(FxaaFloat4 rgba) { return rgba.w; }
+#else
+    FxaaFloat FxaaLuma(FxaaFloat4 rgba) { return rgba.y; }
+#endif
+
+
+/*============================================================================
+
+                             FXAA3 QUALITY - PC
+
+============================================================================*/
+#if (FXAA_PC == 1)
+/*--------------------------------------------------------------------------*/
+FxaaFloat4 FxaaPixelShader(
+    //
+    // Use noperspective interpolation here (turn off perspective interpolation).
+    // {xy} = center of pixel
+    FxaaFloat2 pos,
+    //
+    // Input color texture.
+    // {rgb_} = color in linear or perceptual color space
+    // if (FXAA_GREEN_AS_LUMA == 0)
+    //     {___a} = luma in perceptual color space (not linear)
+    FxaaTex tex,
+	//
+    // Only used on FXAA Quality.
+    // This must be from a constant/uniform.
+    // {x_} = 1.0/screenWidthInPixels
+    // {_y} = 1.0/screenHeightInPixels
+    FxaaFloat2 fxaaQualityRcpFrame,
+    //
+    // Only used on FXAA Quality.
+    // This used to be the FXAA_QUALITY_SUBPIX define.
+    // It is here now to allow easier tuning.
+    // Choose the amount of sub-pixel aliasing removal.
+    // This can effect sharpness.
+    //   1.00 - upper limit (softer)
+    //   0.75 - default amount of filtering
+    //   0.50 - lower limit (sharper, less sub-pixel aliasing removal)
+    //   0.25 - almost off
+    //   0.00 - completely off
+    FxaaFloat fxaaQualitySubpix,
+    //
+    // Only used on FXAA Quality.
+    // This used to be the FXAA_QUALITY_EDGE_THRESHOLD define.
+    // It is here now to allow easier tuning.
+    // The minimum amount of local contrast required to apply algorithm.
+    //   0.333 - too little (faster)
+    //   0.250 - low quality
+    //   0.166 - default
+    //   0.125 - high quality 
+    //   0.063 - overkill (slower)
+    FxaaFloat fxaaQualityEdgeThreshold,
+    //
+    // Only used on FXAA Quality.
+    // This used to be the FXAA_QUALITY_EDGE_THRESHOLD_MIN define.
+    // It is here now to allow easier tuning.
+    // Trims the algorithm from processing darks.
+    //   0.0833 - upper limit (default, the start of visible unfiltered edges)
+    //   0.0625 - high quality (faster)
+    //   0.0312 - visible limit (slower)
+    // Special notes when using FXAA_GREEN_AS_LUMA,
+    //   Likely want to set this to zero.
+    //   As colors that are mostly not-green
+    //   will appear very dark in the green channel!
+    //   Tune by looking at mostly non-green content,
+    //   then start at zero and increase until aliasing is a problem.
+    FxaaFloat fxaaQualityEdgeThresholdMin
+) {
+/*--------------------------------------------------------------------------*/
+    FxaaFloat2 posM;
+    posM.x = pos.x;
+    posM.y = pos.y;
+    #if (FXAA_GATHER4_ALPHA == 1)
+        #if (FXAA_DISCARD == 0)
+            FxaaFloat4 rgbyM = FxaaTexTop(tex, posM);
+            #if (FXAA_GREEN_AS_LUMA == 0)
+                #define lumaM rgbyM.w
+            #else
+                #define lumaM rgbyM.y
+            #endif
+        #endif
+        #if (FXAA_GREEN_AS_LUMA == 0)
+            FxaaFloat4 luma4A = FxaaTexAlpha4(tex, posM);
+            FxaaFloat4 luma4B = FxaaTexOffAlpha4(tex, posM, FxaaInt2(-1, -1));
+        #else
+            FxaaFloat4 luma4A = FxaaTexGreen4(tex, posM);
+            FxaaFloat4 luma4B = FxaaTexOffGreen4(tex, posM, FxaaInt2(-1, -1));
+        #endif
+        #if (FXAA_DISCARD == 1)
+            #define lumaM luma4A.w
+        #endif
+        #define lumaE luma4A.z
+        #define lumaS luma4A.x
+        #define lumaSE luma4A.y
+        #define lumaNW luma4B.w
+        #define lumaN luma4B.z
+        #define lumaW luma4B.x
+    #else
+        FxaaFloat4 rgbyM = FxaaTexTop(tex, posM);
+        #if (FXAA_GREEN_AS_LUMA == 0)
+            #define lumaM rgbyM.w
+        #else
+            #define lumaM rgbyM.y
+        #endif
+        FxaaFloat lumaS = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 0, 1), fxaaQualityRcpFrame.xy));
+        FxaaFloat lumaE = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 1, 0), fxaaQualityRcpFrame.xy));
+        FxaaFloat lumaN = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 0,-1), fxaaQualityRcpFrame.xy));
+        FxaaFloat lumaW = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(-1, 0), fxaaQualityRcpFrame.xy));
+    #endif
+/*--------------------------------------------------------------------------*/
+    FxaaFloat maxSM = max(lumaS, lumaM);
+    FxaaFloat minSM = min(lumaS, lumaM);
+    FxaaFloat maxESM = max(lumaE, maxSM);
+    FxaaFloat minESM = min(lumaE, minSM);
+    FxaaFloat maxWN = max(lumaN, lumaW);
+    FxaaFloat minWN = min(lumaN, lumaW);
+    FxaaFloat rangeMax = max(maxWN, maxESM);
+    FxaaFloat rangeMin = min(minWN, minESM);
+    FxaaFloat rangeMaxScaled = rangeMax * fxaaQualityEdgeThreshold;
+    FxaaFloat range = rangeMax - rangeMin;
+    FxaaFloat rangeMaxClamped = max(fxaaQualityEdgeThresholdMin, rangeMaxScaled);
+    FxaaBool earlyExit = range < rangeMaxClamped;
+/*--------------------------------------------------------------------------*/
+    if(earlyExit)
+        #if (FXAA_DISCARD == 1)
+            FxaaDiscard;
+        #else
+            return rgbyM;
+        #endif
+/*--------------------------------------------------------------------------*/
+    #if (FXAA_GATHER4_ALPHA == 0)
+        FxaaFloat lumaNW = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(-1,-1), fxaaQualityRcpFrame.xy));
+        FxaaFloat lumaSE = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 1, 1), fxaaQualityRcpFrame.xy));
+        FxaaFloat lumaNE = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 1,-1), fxaaQualityRcpFrame.xy));
+        FxaaFloat lumaSW = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(-1, 1), fxaaQualityRcpFrame.xy));
+    #else
+        FxaaFloat lumaNE = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(1, -1), fxaaQualityRcpFrame.xy));
+        FxaaFloat lumaSW = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(-1, 1), fxaaQualityRcpFrame.xy));
+    #endif
+/*--------------------------------------------------------------------------*/
+    FxaaFloat lumaNS = lumaN + lumaS;
+    FxaaFloat lumaWE = lumaW + lumaE;
+    FxaaFloat subpixRcpRange = 1.0/range;
+    FxaaFloat subpixNSWE = lumaNS + lumaWE;
+    FxaaFloat edgeHorz1 = (-2.0 * lumaM) + lumaNS;
+    FxaaFloat edgeVert1 = (-2.0 * lumaM) + lumaWE;
+/*--------------------------------------------------------------------------*/
+    FxaaFloat lumaNESE = lumaNE + lumaSE;
+    FxaaFloat lumaNWNE = lumaNW + lumaNE;
+    FxaaFloat edgeHorz2 = (-2.0 * lumaE) + lumaNESE;
+    FxaaFloat edgeVert2 = (-2.0 * lumaN) + lumaNWNE;
+/*--------------------------------------------------------------------------*/
+    FxaaFloat lumaNWSW = lumaNW + lumaSW;
+    FxaaFloat lumaSWSE = lumaSW + lumaSE;
+    FxaaFloat edgeHorz4 = (abs(edgeHorz1) * 2.0) + abs(edgeHorz2);
+    FxaaFloat edgeVert4 = (abs(edgeVert1) * 2.0) + abs(edgeVert2);
+    FxaaFloat edgeHorz3 = (-2.0 * lumaW) + lumaNWSW;
+    FxaaFloat edgeVert3 = (-2.0 * lumaS) + lumaSWSE;
+    FxaaFloat edgeHorz = abs(edgeHorz3) + edgeHorz4;
+    FxaaFloat edgeVert = abs(edgeVert3) + edgeVert4;
+/*--------------------------------------------------------------------------*/
+    FxaaFloat subpixNWSWNESE = lumaNWSW + lumaNESE;
+    FxaaFloat lengthSign = fxaaQualityRcpFrame.x;
+    FxaaBool horzSpan = edgeHorz >= edgeVert;
+    FxaaFloat subpixA = subpixNSWE * 2.0 + subpixNWSWNESE;
+/*--------------------------------------------------------------------------*/
+    if(!horzSpan) lumaN = lumaW;
+    if(!horzSpan) lumaS = lumaE;
+    if(horzSpan) lengthSign = fxaaQualityRcpFrame.y;
+    FxaaFloat subpixB = (subpixA * (1.0/12.0)) - lumaM;
+/*--------------------------------------------------------------------------*/
+    FxaaFloat gradientN = lumaN - lumaM;
+    FxaaFloat gradientS = lumaS - lumaM;
+    FxaaFloat lumaNN = lumaN + lumaM;
+    FxaaFloat lumaSS = lumaS + lumaM;
+    FxaaBool pairN = abs(gradientN) >= abs(gradientS);
+    FxaaFloat gradient = max(abs(gradientN), abs(gradientS));
+    if(pairN) lengthSign = -lengthSign;
+    FxaaFloat subpixC = FxaaSat(abs(subpixB) * subpixRcpRange);
+/*--------------------------------------------------------------------------*/
+    FxaaFloat2 posB;
+    posB.x = posM.x;
+    posB.y = posM.y;
+    FxaaFloat2 offNP;
+    offNP.x = (!horzSpan) ? 0.0 : fxaaQualityRcpFrame.x;
+    offNP.y = ( horzSpan) ? 0.0 : fxaaQualityRcpFrame.y;
+    if(!horzSpan) posB.x += lengthSign * 0.5;
+    if( horzSpan) posB.y += lengthSign * 0.5;
+/*--------------------------------------------------------------------------*/
+    FxaaFloat2 posN;
+    posN.x = posB.x - offNP.x * FXAA_QUALITY_P0;
+    posN.y = posB.y - offNP.y * FXAA_QUALITY_P0;
+    FxaaFloat2 posP;
+    posP.x = posB.x + offNP.x * FXAA_QUALITY_P0;
+    posP.y = posB.y + offNP.y * FXAA_QUALITY_P0;
+    FxaaFloat subpixD = ((-2.0)*subpixC) + 3.0;
+    FxaaFloat lumaEndN = FxaaLuma(FxaaTexTop(tex, posN));
+    FxaaFloat subpixE = subpixC * subpixC;
+    FxaaFloat lumaEndP = FxaaLuma(FxaaTexTop(tex, posP));
+/*--------------------------------------------------------------------------*/
+    if(!pairN) lumaNN = lumaSS;
+    FxaaFloat gradientScaled = gradient * 1.0/4.0;
+    FxaaFloat lumaMM = lumaM - lumaNN * 0.5;
+    FxaaFloat subpixF = subpixD * subpixE;
+    FxaaBool lumaMLTZero = lumaMM < 0.0;
+/*--------------------------------------------------------------------------*/
+    lumaEndN -= lumaNN * 0.5;
+    lumaEndP -= lumaNN * 0.5;
+    FxaaBool doneN = abs(lumaEndN) >= gradientScaled;
+    FxaaBool doneP = abs(lumaEndP) >= gradientScaled;
+    if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P1;
+    if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P1;
+    FxaaBool doneNP = (!doneN) || (!doneP);
+    if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P1;
+    if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P1;
+/*--------------------------------------------------------------------------*/
+    if(doneNP) {
+        if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+        if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+        if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+        if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+        doneN = abs(lumaEndN) >= gradientScaled;
+        doneP = abs(lumaEndP) >= gradientScaled;
+        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P2;
+        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P2;
+        doneNP = (!doneN) || (!doneP);
+        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P2;
+        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P2;
+/*--------------------------------------------------------------------------*/
+        #if (FXAA_QUALITY_PS > 3)
+        if(doneNP) {
+            if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+            if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+            if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+            if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+            doneN = abs(lumaEndN) >= gradientScaled;
+            doneP = abs(lumaEndP) >= gradientScaled;
+            if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P3;
+            if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P3;
+            doneNP = (!doneN) || (!doneP);
+            if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P3;
+            if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P3;
+/*--------------------------------------------------------------------------*/
+            #if (FXAA_QUALITY_PS > 4)
+            if(doneNP) {
+                if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+                if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+                if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                doneN = abs(lumaEndN) >= gradientScaled;
+                doneP = abs(lumaEndP) >= gradientScaled;
+                if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P4;
+                if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P4;
+                doneNP = (!doneN) || (!doneP);
+                if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P4;
+                if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P4;
+/*--------------------------------------------------------------------------*/
+                #if (FXAA_QUALITY_PS > 5)
+                if(doneNP) {
+                    if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+                    if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+                    if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                    if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                    doneN = abs(lumaEndN) >= gradientScaled;
+                    doneP = abs(lumaEndP) >= gradientScaled;
+                    if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P5;
+                    if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P5;
+                    doneNP = (!doneN) || (!doneP);
+                    if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P5;
+                    if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P5;
+/*--------------------------------------------------------------------------*/
+                    #if (FXAA_QUALITY_PS > 6)
+                    if(doneNP) {
+                        if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+                        if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+                        if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                        if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                        doneN = abs(lumaEndN) >= gradientScaled;
+                        doneP = abs(lumaEndP) >= gradientScaled;
+                        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P6;
+                        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P6;
+                        doneNP = (!doneN) || (!doneP);
+                        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P6;
+                        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P6;
+/*--------------------------------------------------------------------------*/
+                        #if (FXAA_QUALITY_PS > 7)
+                        if(doneNP) {
+                            if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+                            if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+                            if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                            if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                            doneN = abs(lumaEndN) >= gradientScaled;
+                            doneP = abs(lumaEndP) >= gradientScaled;
+                            if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P7;
+                            if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P7;
+                            doneNP = (!doneN) || (!doneP);
+                            if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P7;
+                            if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P7;
+/*--------------------------------------------------------------------------*/
+    #if (FXAA_QUALITY_PS > 8)
+    if(doneNP) {
+        if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+        if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+        if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+        if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+        doneN = abs(lumaEndN) >= gradientScaled;
+        doneP = abs(lumaEndP) >= gradientScaled;
+        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P8;
+        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P8;
+        doneNP = (!doneN) || (!doneP);
+        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P8;
+        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P8;
+/*--------------------------------------------------------------------------*/
+        #if (FXAA_QUALITY_PS > 9)
+        if(doneNP) {
+            if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+            if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+            if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+            if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+            doneN = abs(lumaEndN) >= gradientScaled;
+            doneP = abs(lumaEndP) >= gradientScaled;
+            if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P9;
+            if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P9;
+            doneNP = (!doneN) || (!doneP);
+            if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P9;
+            if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P9;
+/*--------------------------------------------------------------------------*/
+            #if (FXAA_QUALITY_PS > 10)
+            if(doneNP) {
+                if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+                if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+                if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                doneN = abs(lumaEndN) >= gradientScaled;
+                doneP = abs(lumaEndP) >= gradientScaled;
+                if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P10;
+                if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P10;
+                doneNP = (!doneN) || (!doneP);
+                if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P10;
+                if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P10;
+/*--------------------------------------------------------------------------*/
+                #if (FXAA_QUALITY_PS > 11)
+                if(doneNP) {
+                    if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+                    if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+                    if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                    if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                    doneN = abs(lumaEndN) >= gradientScaled;
+                    doneP = abs(lumaEndP) >= gradientScaled;
+                    if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P11;
+                    if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P11;
+                    doneNP = (!doneN) || (!doneP);
+                    if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P11;
+                    if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P11;
+/*--------------------------------------------------------------------------*/
+                    #if (FXAA_QUALITY_PS > 12)
+                    if(doneNP) {
+                        if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+                        if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+                        if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                        if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                        doneN = abs(lumaEndN) >= gradientScaled;
+                        doneP = abs(lumaEndP) >= gradientScaled;
+                        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P12;
+                        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P12;
+                        doneNP = (!doneN) || (!doneP);
+                        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P12;
+                        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P12;
+/*--------------------------------------------------------------------------*/
+                    }
+                    #endif
+/*--------------------------------------------------------------------------*/
+                }
+                #endif
+/*--------------------------------------------------------------------------*/
+            }
+            #endif
+/*--------------------------------------------------------------------------*/
+        }
+        #endif
+/*--------------------------------------------------------------------------*/
+    }
+    #endif
+/*--------------------------------------------------------------------------*/
+                        }
+                        #endif
+/*--------------------------------------------------------------------------*/
+                    }
+                    #endif
+/*--------------------------------------------------------------------------*/
+                }
+                #endif
+/*--------------------------------------------------------------------------*/
+            }
+            #endif
+/*--------------------------------------------------------------------------*/
+        }
+        #endif
+/*--------------------------------------------------------------------------*/
+    }
+/*--------------------------------------------------------------------------*/
+    FxaaFloat dstN = posM.x - posN.x;
+    FxaaFloat dstP = posP.x - posM.x;
+    if(!horzSpan) dstN = posM.y - posN.y;
+    if(!horzSpan) dstP = posP.y - posM.y;
+/*--------------------------------------------------------------------------*/
+    FxaaBool goodSpanN = (lumaEndN < 0.0) != lumaMLTZero;
+    FxaaFloat spanLength = (dstP + dstN);
+    FxaaBool goodSpanP = (lumaEndP < 0.0) != lumaMLTZero;
+    FxaaFloat spanLengthRcp = 1.0/spanLength;
+/*--------------------------------------------------------------------------*/
+    FxaaBool directionN = dstN < dstP;
+    FxaaFloat dst = min(dstN, dstP);
+    FxaaBool goodSpan = directionN ? goodSpanN : goodSpanP;
+    FxaaFloat subpixG = subpixF * subpixF;
+    FxaaFloat pixelOffset = (dst * (-spanLengthRcp)) + 0.5;
+    FxaaFloat subpixH = subpixG * fxaaQualitySubpix;
+/*--------------------------------------------------------------------------*/
+    FxaaFloat pixelOffsetGood = goodSpan ? pixelOffset : 0.0;
+    FxaaFloat pixelOffsetSubpix = max(pixelOffsetGood, subpixH);
+    if(!horzSpan) posM.x += pixelOffsetSubpix * lengthSign;
+    if( horzSpan) posM.y += pixelOffsetSubpix * lengthSign;
+    #if (FXAA_DISCARD == 1)
+        return FxaaTexTop(tex, posM);
+    #else
+        return FxaaFloat4(FxaaTexTop(tex, posM).xyz, lumaM);
+    #endif
+}
+/*==========================================================================*/
+#endif
+
+//----------------------------------------------------------------------------------
+// File:        es3-kepler\FXAA\assets\shaders/FXAA_Default.frag
+// SDK Version: v3.00 
+// Email:       gameworks@nvidia.com
+// Site:        http://developer.nvidia.com/
+//
+// Copyright (c) 2014-2015, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//----------------------------------------------------------------------------------
+//#version 100
+
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
+layout(location = 0) in vec4 passParameterSem2;
+layout(location = 0) out vec4 passPixelColor0;
+
+
+ivec2 resolution = textureSize(textureUnitPS0,0); // Retrieve Texture Dimensions in float data type so we dont need to convert
+
+precision highp float;
+
+vec2 RcpFrame = vec2(1.0 / float(resolution.x), 1.0 / float(resolution.y));
+void main()
+{
+passPixelColor0 = FxaaPixelShader(passParameterSem2.xy, textureUnitPS0, RcpFrame, Subpix, EdgeThreshold, EdgeThresholdMin);
+}
+
+#endif

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/f69e84515ae56e70_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/f69e84515ae56e70_0000000000000000_vs.txt
@@ -1,0 +1,118 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader f69e84515ae56e70
+// Used for: Vertical Bloom Blur
+// bloom blur v
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 0) out vec4 passParameterSem0;
+layout(location = 1) out vec4 passParameterSem1;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R2f = vec4(0.0);
+vec4 R127f = vec4(0.0);
+uvec4 attrDecoder;
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = floatBitsToInt(ivec4(gl_VertexID, 0, 0, gl_InstanceID));
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R1f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(floatBitsToInt(1.0)));
+attrDecoder.xy = attrDataSem1.xy;
+attrDecoder.xy = (attrDecoder.xy>>24)|((attrDecoder.xy>>8)&0xFF00)|((attrDecoder.xy<<8)&0xFF0000)|((attrDecoder.xy<<24));
+attrDecoder.z = 0;
+attrDecoder.w = 0;
+R2f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(floatBitsToInt(0.0)), intBitsToFloat(floatBitsToInt(1.0)));
+// 0
+backupReg0f = R1f.x;
+backupReg1f = R1f.y;
+R1f.x = backupReg0f;
+R1f.x *= 2.0;
+R1f.y = backupReg1f;
+R1f.y *= 2.0;
+R1f.z = 0.0;
+R1f.w = 1.0;
+PS0f = intBitsToFloat(uf_remappedVS[0].y) / resYScale * intBitsToFloat(0x3fb13a93);
+// 1
+R127f.x = intBitsToFloat(uf_remappedVS[0].y) / resYScale * intBitsToFloat(0x404ec4f0);
+PV1f.x = R127f.x;
+R0f.y = R2f.y + -(PS0f);
+R2f.z = R2f.y + PS0f;
+PV1f.z = R2f.z;
+R2f.w = R2f.y;
+PV1f.w = R2f.w;
+R0f.x = R2f.x;
+PS1f = R0f.x;
+// 2
+R0f.z = PV1f.z;
+R0f.w = PV1f.w;
+R2f.z = R2f.y + PV1f.x;
+PS0f = R2f.z;
+// 3
+backupReg0f = R2f.y;
+backupReg0f = R2f.y;
+R2f.y = backupReg0f + -(R127f.x);
+R2f.w = backupReg0f;
+// export
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
+// export
+passParameterSem0 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
+// export
+passParameterSem1 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/fc3e63a2007625f8_0000000000000000_vs.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/fc3e63a2007625f8_0000000000000000_vs.txt
@@ -1,0 +1,132 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader fc3e63a2007625f8
+// Used For: Vertical Menu Blur
+const float resXScale = float($width)/float($gameWidth);
+const float resYScale = float($height)/float($gameHeight);
+
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 0) out vec4 passParameterSem0;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R126f = vec4(0.0);
+vec4 R127f = vec4(0.0);
+uvec4 attrDecoder;
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = floatBitsToInt(ivec4(gl_VertexID, 0, 0, gl_InstanceID));
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R1f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(floatBitsToInt(1.0)));
+// 0
+R127f.x = -(R1f.y);
+PV0f.x = R127f.x;
+R127f.y = (R1f.x > 0.0)?1.0:0.0;
+R127f.y /= 2.0;
+R126f.z = (0.0 > R1f.x)?1.0:0.0;
+R126f.z /= 2.0;
+R127f.w = 1.0;
+PV0f.w = R127f.w;
+R126f.x = intBitsToFloat(uf_remappedVS[0].w) * (intBitsToFloat(0x3fae8a72)/resYScale);
+PS0f = R126f.x;
+// 1
+R0f.x = dot(vec4(R1f.x,R1f.y,R1f.z,PV0f.w),vec4(intBitsToFloat(uf_remappedVS[1].x),intBitsToFloat(uf_remappedVS[1].y),intBitsToFloat(uf_remappedVS[1].z),intBitsToFloat(uf_remappedVS[1].w)));
+PV1f.x = R0f.x;
+PV1f.y = R0f.x;
+PV1f.z = R0f.x;
+PV1f.w = R0f.x;
+R127f.z = (PV0f.x > 0.0)?1.0:0.0;
+R127f.z /= 2.0;
+PS1f = R127f.z;
+// 2
+tempf.x = dot(vec4(R1f.x,R1f.y,R1f.z,R127f.w),vec4(intBitsToFloat(uf_remappedVS[2].x),intBitsToFloat(uf_remappedVS[2].y),intBitsToFloat(uf_remappedVS[2].z),intBitsToFloat(uf_remappedVS[2].w)));
+PV0f.x = tempf.x;
+PV0f.y = tempf.x;
+PV0f.z = tempf.x;
+PV0f.w = tempf.x;
+R0f.y = tempf.x;
+PS0f = (0.0 > R127f.x)?1.0:0.0;
+PS0f /= 2.0;
+// 3
+backupReg0f = R127f.z;
+tempf.x = dot(vec4(R1f.x,R1f.y,R1f.z,R127f.w),vec4(intBitsToFloat(uf_remappedVS[3].x),intBitsToFloat(uf_remappedVS[3].y),intBitsToFloat(uf_remappedVS[3].z),intBitsToFloat(uf_remappedVS[3].w)));
+PV1f.x = tempf.x;
+PV1f.y = tempf.x;
+PV1f.z = tempf.x;
+PV1f.w = tempf.x;
+R0f.z = tempf.x;
+R127f.z = backupReg0f + -(PS0f);
+PS1f = R127f.z;
+// 4
+tempf.x = dot(vec4(R1f.x,R1f.y,R1f.z,R127f.w),vec4(intBitsToFloat(uf_remappedVS[4].x),intBitsToFloat(uf_remappedVS[4].y),intBitsToFloat(uf_remappedVS[4].z),intBitsToFloat(uf_remappedVS[4].w)));
+PV0f.x = tempf.x;
+PV0f.y = tempf.x;
+PV0f.z = tempf.x;
+PV0f.w = tempf.x;
+R0f.w = tempf.x;
+PS0f = R127f.y + -(R126f.z);
+// 5
+R1f.x = PS0f + 0.5;
+PV1f.y = R127f.z + 0.5;
+// 6
+R1f.y = PV1f.y + -(R126f.x);
+R1f.z = PV1f.y + R126f.x;
+R1f.w = PV1f.y;
+// export
+SET_POSITION(vec4(R0f.x, R0f.y, R0f.z, R0f.w));
+// export
+passParameterSem0 = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/ffe0e8c84f6e8da9_000003c000009269_ps.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/ffe0e8c84f6e8da9_000003c000009269_ps.txt
@@ -1,0 +1,729 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+// shader ffe0e8c84f6e8da9
+// Shadow 2x2 box blur fix
+// shader dumped from BotW v1.3.1, using Cemu 1.10.0
+const float resScale = $shadowRes;
+
+UNIFORM_BUFFER_LAYOUT(33, 1, 7) uniform uniformBlockPS1
+{
+vec4 uf_blockPS1[1024];
+};
+
+UNIFORM_BUFFER_LAYOUT(38, 1, 8) uniform uniformBlockPS6
+{
+vec4 uf_blockPS6[1024];
+};
+
+UNIFORM_BUFFER_LAYOUT(42, 1, 9) uniform uniformBlockPS10
+{
+vec4 uf_blockPS10[1024];
+};
+
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
+TEXTURE_LAYOUT(3, 1, 2) uniform sampler2D textureUnitPS3;
+TEXTURE_LAYOUT(6, 1, 3) uniform sampler2D textureUnitPS6;
+TEXTURE_LAYOUT(8, 1, 4) uniform sampler2DArrayShadow textureUnitPS8;
+TEXTURE_LAYOUT(15, 1, 5) uniform sampler2D textureUnitPS15;
+layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem5;
+layout(location = 2) in vec4 passParameterSem6;
+layout(location = 5) out vec4 passPixelColor5;
+#ifdef VULKAN
+layout(set = 1, binding = 6) uniform ufBlock
+{
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform vec2 uf_fragCoordScale;
+#endif
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+ivec4 R0i = ivec4(0);
+ivec4 R1i = ivec4(0);
+ivec4 R2i = ivec4(0);
+ivec4 R3i = ivec4(0);
+ivec4 R4i = ivec4(0);
+ivec4 R5i = ivec4(0);
+ivec4 R6i = ivec4(0);
+ivec4 R7i = ivec4(0);
+ivec4 R8i = ivec4(0);
+ivec4 R9i = ivec4(0);
+ivec4 R10i = ivec4(0);
+ivec4 R11i = ivec4(0);
+ivec4 R12i = ivec4(0);
+ivec4 R13i = ivec4(0);
+ivec4 R14i = ivec4(0);
+ivec4 R15i = ivec4(0);
+ivec4 R16i = ivec4(0);
+ivec4 R122i = ivec4(0);
+ivec4 R123i = ivec4(0);
+ivec4 R124i = ivec4(0);
+ivec4 R125i = ivec4(0);
+ivec4 R126i = ivec4(0);
+ivec4 R127i = ivec4(0);
+int backupReg0i, backupReg1i, backupReg2i, backupReg3i, backupReg4i;
+ivec4 PV0i = ivec4(0), PV1i = ivec4(0);
+int PS0i = 0, PS1i = 0;
+ivec4 tempi = ivec4(0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+bool activeMaskStack[3];
+bool activeMaskStackC[4];
+activeMaskStack[0] = false;
+activeMaskStack[1] = false;
+activeMaskStackC[0] = false;
+activeMaskStackC[1] = false;
+activeMaskStackC[2] = false;
+activeMaskStack[0] = true;
+activeMaskStackC[0] = true;
+activeMaskStackC[1] = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0i = floatBitsToInt(passParameterSem0);
+R1i = floatBitsToInt(passParameterSem5);
+R2i = floatBitsToInt(passParameterSem6);
+if( activeMaskStackC[1] == true ) {
+R3i.w = floatBitsToInt(texture(textureUnitPS6, intBitsToFloat(R0i.xy)).x);
+R6i.xzw = floatBitsToInt(textureGather(textureUnitPS6, vec2(0.0001) + intBitsToFloat(R0i.xy)).xzw);
+R4i.xyzw = floatBitsToInt(texture(textureUnitPS3, intBitsToFloat(R2i.zw)).xyzw);
+R2i.xy = floatBitsToInt(texture(textureUnitPS0, intBitsToFloat(R2i.xy)).xw);
+}
+if( activeMaskStackC[1] == true ) {
+// 0
+R123i.x = floatBitsToInt((mul_nonIEEE(uf_blockPS1[16].x,intBitsToFloat(R6i.w)) + uf_blockPS1[14].x));
+PV0i.x = R123i.x;
+R127i.y = floatBitsToInt((mul_nonIEEE(uf_blockPS1[16].x,intBitsToFloat(R6i.z)) + uf_blockPS1[14].x));
+R127i.z = floatBitsToInt((mul_nonIEEE(uf_blockPS1[16].x,intBitsToFloat(R6i.x)) + uf_blockPS1[14].x));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R3i.w),uf_blockPS1[16].x) + uf_blockPS1[14].x));
+PV0i.w = R123i.w;
+R127i.x = floatBitsToInt((intBitsToFloat(R4i.x) * 2.0 + -(1.0)));
+PS0i = R127i.x;
+// 1
+R7i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R0i.z), -(intBitsToFloat(PV0i.w))));
+R6i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R0i.w), -(intBitsToFloat(PV0i.w))));
+R12i.z = floatBitsToInt(-(intBitsToFloat(PV0i.x)));
+R127i.w = floatBitsToInt((intBitsToFloat(R4i.y) * 2.0 + -(1.0)));
+R125i.z = floatBitsToInt((intBitsToFloat(R4i.z) * 2.0 + -(1.0)));
+PS1i = R125i.z;
+// 2
+PV0i.x = floatBitsToInt(-(intBitsToFloat(R127i.y)));
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.y), -(intBitsToFloat(R127i.y))));
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.x), -(intBitsToFloat(R127i.y))));
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.z), -(intBitsToFloat(R127i.z))));
+R126i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.w), -(intBitsToFloat(R127i.z))));
+PS0i = R126i.z;
+// 3
+R125i.x = floatBitsToInt(-(intBitsToFloat(R7i.x)) + intBitsToFloat(PV0i.z));
+R127i.y = floatBitsToInt(-(intBitsToFloat(R127i.z)));
+R124i.z = floatBitsToInt(-(intBitsToFloat(R12i.z)) + intBitsToFloat(PV0i.x));
+R125i.w = floatBitsToInt(-(intBitsToFloat(R6i.y)) + intBitsToFloat(PV0i.y));
+R126i.y = floatBitsToInt(-(intBitsToFloat(R7i.x)) + intBitsToFloat(PV0i.w));
+PS1i = R126i.y;
+// 4
+backupReg0i = R126i.z;
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R7i.x),intBitsToFloat(R6i.y),intBitsToFloat(R12i.z),-0.0),vec4(intBitsToFloat(R7i.x),intBitsToFloat(R6i.y),intBitsToFloat(R12i.z),0.0)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+R126i.z = tempi.x;
+R126i.x = floatBitsToInt(-(intBitsToFloat(R6i.y)) + intBitsToFloat(backupReg0i));
+PS0i = R126i.x;
+// 5
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R127i.x),intBitsToFloat(R127i.w),intBitsToFloat(R125i.z),-0.0),vec4(intBitsToFloat(R127i.x),intBitsToFloat(R127i.w),intBitsToFloat(R125i.z),0.0)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R127i.z = tempi.x;
+R126i.w = floatBitsToInt(-(intBitsToFloat(R12i.z)) + intBitsToFloat(R127i.y));
+PS1i = R126i.w;
+// 6
+backupReg0i = R126i.z;
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R7i.x), uf_blockPS6[43].x));
+R127i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.z), intBitsToFloat(R126i.y)));
+R126i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.w), intBitsToFloat(PS1i)));
+R124i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.x), intBitsToFloat(R126i.x)));
+R125i.y = floatBitsToInt(sqrt(intBitsToFloat(backupReg0i)));
+PS0i = R125i.y;
+// 7
+backupReg0i = R127i.z;
+R124i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R7i.x), uf_blockPS6[45].x));
+R124i.y = floatBitsToInt(intBitsToFloat(R4i.w) * intBitsToFloat(0x437f0000));
+R127i.z = floatBitsToInt((intBitsToFloat(R2i.x) * 2.0 + -(1.0)));
+R4i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.y),uf_blockPS6[43].y) + intBitsToFloat(PV0i.x)));
+tempResultf = 1.0 / sqrt(intBitsToFloat(backupReg0i));
+PS1i = floatBitsToInt(tempResultf);
+// 8
+backupReg0i = R125i.z;
+R8i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(PS1i)));
+R7i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.w), intBitsToFloat(PS1i)));
+R125i.z = floatBitsToInt(mul_nonIEEE(uf_blockPS1[18].y, uf_blockPS1[18].z));
+PV0i.z = R125i.z;
+R127i.w = floatBitsToInt(-(intBitsToFloat(R12i.z)) * intBitsToFloat(0x3d4ccccd));
+R9i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), intBitsToFloat(PS1i)));
+PS0i = R9i.z;
+// 9
+R1i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R126i.x)),intBitsToFloat(R124i.z)) + intBitsToFloat(R126i.z)));
+R1i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R126i.w)),intBitsToFloat(R125i.x)) + intBitsToFloat(R127i.y)));
+R126i.z = floatBitsToInt((intBitsToFloat(R2i.y) * 2.0 + -(1.0)));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.y),uf_blockPS6[45].y) + intBitsToFloat(R124i.x)));
+PV1i.w = R123i.w;
+R126i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.z), intBitsToFloat(R127i.z)));
+PS1i = R126i.w;
+// 10
+backupReg0i = R126i.y;
+R126i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.z),uf_blockPS6[45].z) + intBitsToFloat(PV1i.w)));
+R126i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.z),uf_blockPS6[43].z) + intBitsToFloat(R4i.w)));
+R1i.z = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(backupReg0i)),intBitsToFloat(R125i.w)) + intBitsToFloat(R124i.w)));
+PV0i.z = R1i.z;
+R125i.w = R8i.x;
+R125i.w = floatBitsToInt(intBitsToFloat(R125i.w) * 2.0);
+R124i.z = R7i.y;
+R124i.z = floatBitsToInt(intBitsToFloat(R124i.z) * 2.0);
+PS0i = R124i.z;
+// 11
+R124i.x = floatBitsToInt(dot(vec4(-(intBitsToFloat(R1i.x)),-(intBitsToFloat(R1i.y)),-(intBitsToFloat(PV0i.z)),-0.0),vec4(-(intBitsToFloat(R1i.x)),-(intBitsToFloat(R1i.y)),-(intBitsToFloat(PV0i.z)),0.0)));
+PV1i.x = R124i.x;
+PV1i.y = R124i.x;
+PV1i.z = R124i.x;
+PV1i.w = R124i.x;
+R2i.x = floatBitsToInt((-(uf_blockPS6[53].w) * intBitsToFloat(0x3d4ccccd) + intBitsToFloat(R127i.w)));
+R2i.x = clampFI32(R2i.x);
+PS1i = R2i.x;
+// 12
+R125i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.z), -(intBitsToFloat(R126i.z))));
+PV0i.x = R125i.x;
+R127i.y = floatBitsToInt(intBitsToFloat(R126i.z) * intBitsToFloat(0xbb6fe5d7));
+PV0i.z = floatBitsToInt(intBitsToFloat(R126i.w) * intBitsToFloat(0x3ca30589));
+PV0i.w = floatBitsToInt(intBitsToFloat(R126i.z) * intBitsToFloat(0x3ca30589));
+R126i.z = floatBitsToInt(intBitsToFloat(R126i.w) * intBitsToFloat(0xbb6fe5d7));
+PS0i = R126i.z;
+// 13
+R10i.x = floatBitsToInt(uf_blockPS6[43].w + intBitsToFloat(R126i.y));
+R3i.y = floatBitsToInt((intBitsToFloat(R127i.z) * intBitsToFloat(0x3b02da3b) + intBitsToFloat(PV0i.w)));
+R2i.z = floatBitsToInt(mul_nonIEEE(-(intBitsToFloat(R12i.z)), uf_blockPS1[17].y));
+R1i.w = 0x3f800000;
+R4i.x = floatBitsToInt((intBitsToFloat(PV0i.x) * intBitsToFloat(0x3b02da3b) + intBitsToFloat(PV0i.z)));
+PS1i = R4i.x;
+// 14
+R3i.x = floatBitsToInt((intBitsToFloat(R125i.x) * intBitsToFloat(0x3d156fb9) + intBitsToFloat(R126i.z)));
+R2i.y = floatBitsToInt((intBitsToFloat(R127i.z) * intBitsToFloat(0x3d156fb9) + intBitsToFloat(R127i.y)));
+R11i.z = floatBitsToInt(uf_blockPS6[45].w + intBitsToFloat(R126i.x));
+R10i.w = floatBitsToInt((-(uf_blockPS6[53].z) * intBitsToFloat(0x3d4ccccd) + intBitsToFloat(R127i.w)));
+R10i.w = clampFI32(R10i.w);
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(R125i.y));
+// 15
+backupReg0i = R124i.y;
+R126i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R7i.x), intBitsToFloat(PS0i)));
+PV1i.x = R126i.x;
+R124i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R6i.y), intBitsToFloat(PS0i)));
+PV1i.y = R124i.y;
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R12i.z), intBitsToFloat(PS0i)));
+PS1i = int(intBitsToFloat(backupReg0i));
+// 16
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R8i.x),intBitsToFloat(R7i.y),intBitsToFloat(R9i.z),-0.0),vec4(intBitsToFloat(PV1i.x),intBitsToFloat(PV1i.y),intBitsToFloat(PV1i.z),0.0)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+PS0i = PS1i & int(1);
+// 17
+R11i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(PV0i.x)),intBitsToFloat(R125i.w)) + intBitsToFloat(R126i.x)));
+R10i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(PV0i.x)),intBitsToFloat(R124i.z)) + intBitsToFloat(R124i.y)));
+R11i.w = floatBitsToInt(intBitsToFloat(PV0i.x) + 1.0);
+R11i.w = clampFI32(R11i.w);
+R8i.y = ((PS0i == 0)?(0):(0x3f800000));
+PS1i = R8i.y;
+// 18
+tempResultf = 1.0 / sqrt(intBitsToFloat(R124i.x));
+R2i.w = floatBitsToInt(tempResultf);
+PS0i = R2i.w;
+}
+if( activeMaskStackC[1] == true ) {
+activeMaskStack[1] = activeMaskStack[0];
+activeMaskStackC[2] = activeMaskStackC[1];
+// 0
+PV0i.x = floatBitsToInt(uf_blockPS10[2].z + 1.0);
+R9i.y = floatBitsToInt(mul_nonIEEE(uf_blockPS6[4].y, uf_blockPS10[2].w));
+R9i.x = floatBitsToInt(mul_nonIEEE(uf_blockPS6[4].x, uf_blockPS10[2].w));
+PS0i = R9i.x;
+// 1
+R10i.z = floatBitsToInt(mul_nonIEEE(uf_blockPS6[4].z, uf_blockPS10[2].w));
+R12i.w = floatBitsToInt(-(intBitsToFloat(R2i.x)) + intBitsToFloat(PV0i.x));
+R12i.w = clampFI32(R12i.w);
+R7i.w = 0;
+PS1i = R7i.w;
+// 2
+predResult = (1.0 > intBitsToFloat(R10i.w));
+activeMaskStack[1] = predResult;
+activeMaskStackC[2] = predResult == true && activeMaskStackC[1] == true;
+}
+else {
+activeMaskStack[1] = false;
+activeMaskStackC[2] = false;
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+R12i.x = floatBitsToInt(intBitsToFloat(R0i.x) + intBitsToFloat(R4i.x));
+R12i.y = floatBitsToInt(intBitsToFloat(R0i.y) + intBitsToFloat(R3i.y));
+R13i.x = floatBitsToInt(intBitsToFloat(R0i.x) + -(intBitsToFloat(R4i.x)));
+PS0i = R13i.x;
+// 1
+R14i.x = floatBitsToInt(intBitsToFloat(R0i.x) + intBitsToFloat(R3i.x));
+R13i.y = floatBitsToInt(intBitsToFloat(R0i.y) + -(intBitsToFloat(R3i.y)));
+R14i.y = floatBitsToInt(intBitsToFloat(R0i.y) + intBitsToFloat(R2i.y));
+PS1i = R14i.y;
+// 2
+R15i.x = floatBitsToInt(intBitsToFloat(R0i.x) + -(intBitsToFloat(R3i.x)));
+R15i.y = floatBitsToInt(intBitsToFloat(R0i.y) + -(intBitsToFloat(R2i.y)));
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+R127i.x = ((-(intBitsToFloat(R12i.z)) > uf_blockPS1[58].y)?int(0xFFFFFFFF):int(0x0));
+PV0i.y = floatBitsToInt(intBitsToFloat(R7i.y) * 1.5);
+PV0i.z = floatBitsToInt(intBitsToFloat(R8i.x) * 1.5);
+PV0i.w = ((-(intBitsToFloat(R12i.z)) > uf_blockPS1[58].x)?int(0xFFFFFFFF):int(0x0));
+PS0i = floatBitsToInt(intBitsToFloat(R9i.z) * 1.5);
+// 1
+backupReg0i = R1i.x;
+backupReg1i = R1i.z;
+R1i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(backupReg0i)),intBitsToFloat(R2i.w)) + intBitsToFloat(PV0i.z)));
+PV1i.y = PV0i.w & int(1);
+R1i.z = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R1i.y)),intBitsToFloat(R2i.w)) + intBitsToFloat(PV0i.y)));
+R1i.w = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(backupReg1i)),intBitsToFloat(R2i.w)) + intBitsToFloat(PS0i)));
+R122i.x = floatBitsToInt((intBitsToFloat(R2i.z) * 0.25 + 1.0));
+PS1i = R122i.x;
+// 2
+R2i.x = floatBitsToInt(intBitsToFloat(0x3da22222) * intBitsToFloat(PS1i));
+R2i.y = floatBitsToInt(intBitsToFloat(0x3da22222) * intBitsToFloat(PS1i));
+R2i.z = floatBitsToInt(intBitsToFloat(0x3da22222) * intBitsToFloat(PS1i));
+R13i.w = PV1i.y - R127i.x;
+PV0i.w = R13i.w;
+PS0i = floatBitsToInt(uf_blockPS6[53].y/resScale);
+PS0i = floatBitsToInt(intBitsToFloat(PS0i) / 2.0);
+// 3
+R6i.x = floatBitsToInt(uf_blockPS6[53].x/resScale);
+R6i.x = floatBitsToInt(intBitsToFloat(R6i.x) / 2.0);
+PV1i.y = PV0i.w << 0x00000002;
+R6i.z = floatBitsToInt(-(intBitsToFloat(PS0i)));
+R2i.w = PS0i;
+PS1i = floatBitsToInt(float(PV0i.w));
+// 4
+R0i.x = PV1i.y + 0x0000002b;
+R0i.y = PV1i.y + 0x0000002d;
+R0i.z = PV1i.y + 0x0000002a;
+R0i.w = PV1i.y + 0x0000002c;
+R7i.z = floatBitsToInt(roundEven(intBitsToFloat(PS1i)));
+PS0i = R7i.z;
+// 5
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R1i.x),intBitsToFloat(R1i.z),intBitsToFloat(R1i.w),-0.0),vec4(intBitsToFloat(R1i.x),intBitsToFloat(R1i.z),intBitsToFloat(R1i.w),0.0)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R1i.y = tempi.x;
+R8i.z = PS0i;
+PS1i = R8i.z;
+}
+if( activeMaskStackC[2] == true ) {
+R3i.xyzw = floatBitsToInt(uf_blockPS1[R0i.y].xyzw);
+R4i.xyzw = floatBitsToInt(uf_blockPS1[R0i.w].xyzw);
+R5i.xyzw = floatBitsToInt(uf_blockPS1[R0i.z].xyzw);
+R0i.xyzw = floatBitsToInt(uf_blockPS1[R0i.x].xyzw);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+R126i.x = floatBitsToInt(dot(vec4(intBitsToFloat(R8i.x),intBitsToFloat(R7i.y),intBitsToFloat(R9i.z),intBitsToFloat(R9i.z)),vec4(-(intBitsToFloat(R9i.x)),-(intBitsToFloat(R9i.y)),-(intBitsToFloat(R10i.z)),-(intBitsToFloat(R7i.w)))));
+R126i.x = clampFI32(R126i.x);
+PV0i.x = R126i.x;
+PV0i.y = R126i.x;
+PV0i.z = R126i.x;
+PV0i.w = R126i.x;
+tempResultf = 1.0 / sqrt(intBitsToFloat(R1i.y));
+PS0i = floatBitsToInt(tempResultf);
+// 1
+R127i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.x), intBitsToFloat(PS0i)));
+PV1i.x = R127i.x;
+R127i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.z), intBitsToFloat(PS0i)));
+PV1i.y = R127i.y;
+R127i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.w), intBitsToFloat(PS0i)));
+PV1i.z = R127i.z;
+R126i.w = floatBitsToInt(-(intBitsToFloat(R6i.x)));
+R1i.z = R7i.z;
+PS1i = R1i.z;
+// 2
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R9i.x),intBitsToFloat(R9i.y),intBitsToFloat(R10i.z),-0.0),vec4(intBitsToFloat(PV1i.x),intBitsToFloat(PV1i.y),intBitsToFloat(PV1i.z),0.0)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+R9i.z = R7i.z;
+PS0i = R9i.z;
+// 3
+R123i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(PV0i.x)),intBitsToFloat(PV0i.x)) + 1.0));
+PV1i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R9i.x)),intBitsToFloat(PV0i.x)) + intBitsToFloat(R127i.x)));
+PV1i.y = R123i.y;
+R123i.z = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R10i.z)),intBitsToFloat(PV0i.x)) + intBitsToFloat(R127i.z)));
+PV1i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R9i.y)),intBitsToFloat(PV0i.x)) + intBitsToFloat(R127i.y)));
+PV1i.w = R123i.w;
+// 4
+backupReg0i = R126i.x;
+R126i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.w), intBitsToFloat(R2i.y)));
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.x), intBitsToFloat(backupReg0i)));
+R127i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.y), intBitsToFloat(R2i.x)));
+R127i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.z), intBitsToFloat(R2i.z)));
+// 5
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R8i.y), intBitsToFloat(PV0i.y)));
+// 6
+backupReg0i = R6i.y;
+R16i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.z),intBitsToFloat(PV1i.z)) + intBitsToFloat(R7i.x)));
+PV0i.x = R16i.x;
+R6i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R126i.x),intBitsToFloat(PV1i.z)) + intBitsToFloat(backupReg0i)));
+R10i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.w),intBitsToFloat(PV1i.z)) + intBitsToFloat(R12i.z)));
+// 7
+PV1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.x), intBitsToFloat(R4i.x)));
+R127i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.x), intBitsToFloat(R5i.x)));
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.x), intBitsToFloat(R3i.x)));
+// 8
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.y),intBitsToFloat(R3i.y)) + intBitsToFloat(PV1i.z)));
+PV0i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.y),intBitsToFloat(R4i.y)) + intBitsToFloat(PV1i.x)));
+PV0i.y = R123i.y;
+R127i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R16i.x), intBitsToFloat(R0i.x)));
+// 9
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.y),intBitsToFloat(R5i.y)) + intBitsToFloat(R127i.y)));
+PV1i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R10i.z),intBitsToFloat(R4i.z)) + intBitsToFloat(PV0i.y)));
+PV1i.y = R123i.y;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R10i.z),intBitsToFloat(R3i.z)) + intBitsToFloat(PV0i.x)));
+PV1i.w = R123i.w;
+// 10
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.y),intBitsToFloat(R0i.y)) + intBitsToFloat(R127i.z)));
+PV0i.x = R123i.x;
+PV0i.y = floatBitsToInt(intBitsToFloat(R3i.w) + intBitsToFloat(PV1i.w));
+R127i.z = floatBitsToInt(intBitsToFloat(R4i.w) + intBitsToFloat(PV1i.y));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R10i.z),intBitsToFloat(R5i.z)) + intBitsToFloat(PV1i.x)));
+PV0i.w = R123i.w;
+// 11
+PV1i.y = floatBitsToInt(intBitsToFloat(R5i.w) + intBitsToFloat(PV0i.w));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R10i.z),intBitsToFloat(R0i.z)) + intBitsToFloat(PV0i.x)));
+PV1i.w = R123i.w;
+R126i.z = floatBitsToInt(1.0 / intBitsToFloat(PV0i.y));
+PS1i = R126i.z;
+// 12
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.z), intBitsToFloat(PS1i)));
+PV0i.y = floatBitsToInt(intBitsToFloat(R0i.w) + intBitsToFloat(PV1i.w));
+R127i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.y), intBitsToFloat(PS1i)));
+PV0i.z = R127i.z;
+// 13
+R7i.x = floatBitsToInt((uf_blockPS6[53].x / resScale * 0.5 + intBitsToFloat(PV0i.z)));
+R127i.y = floatBitsToInt(intBitsToFloat(PV0i.x) + intBitsToFloat(0xbb03126f));
+R127i.y = clampFI32(R127i.y);
+PV1i.y = R127i.y;
+R127i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.y), intBitsToFloat(R126i.z)));
+PV1i.w = R127i.w;
+R8i.x = floatBitsToInt(intBitsToFloat(PV0i.z) + intBitsToFloat(R6i.x));
+PS1i = R8i.x;
+// 14
+R1i.x = floatBitsToInt(intBitsToFloat(R127i.z) + intBitsToFloat(R126i.w));
+R7i.y = floatBitsToInt((uf_blockPS6[53].y / resScale * 0.5 + intBitsToFloat(PV1i.w)));
+R7i.w = PV1i.y;
+R8i.y = floatBitsToInt(intBitsToFloat(PV1i.w) + intBitsToFloat(R6i.z));
+PS0i = R8i.y;
+// 15
+R9i.x = floatBitsToInt((-(uf_blockPS6[53].x) / resScale * 0.5 + intBitsToFloat(R127i.z)));
+R1i.y = floatBitsToInt(intBitsToFloat(R127i.w) + intBitsToFloat(R2i.w));
+R8i.w = R127i.y;
+R1i.w = R127i.y;
+PS1i = R1i.w;
+// 16
+R9i.y = floatBitsToInt((-(uf_blockPS6[53].y) / resScale * 0.5 + intBitsToFloat(R127i.w)));
+R9i.w = R127i.y;
+}
+if( activeMaskStackC[2] == true ) {
+R7i.z = floatBitsToInt(texture(textureUnitPS8, vec4(intBitsToFloat(R7i.x),intBitsToFloat(R7i.y),intBitsToFloat(R7i.z),intBitsToFloat(R7i.w))));
+R8i.y = floatBitsToInt(texture(textureUnitPS8, vec4(intBitsToFloat(R8i.x),intBitsToFloat(R8i.y),intBitsToFloat(R8i.z),intBitsToFloat(R8i.w))));
+R1i.x = floatBitsToInt(texture(textureUnitPS8, vec4(intBitsToFloat(R1i.x),intBitsToFloat(R1i.y),intBitsToFloat(R1i.z),intBitsToFloat(R1i.w))));
+R9i.w = floatBitsToInt(texture(textureUnitPS8, vec4(intBitsToFloat(R9i.x),intBitsToFloat(R9i.y),intBitsToFloat(R9i.z),intBitsToFloat(R9i.w))));
+}
+if( activeMaskStackC[2] == true ) {
+activeMaskStack[2] = activeMaskStack[1];
+activeMaskStackC[3] = activeMaskStackC[2];
+// 0
+PV0i.w = floatBitsToInt(intBitsToFloat(R7i.z) + intBitsToFloat(R8i.y));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV0i.w) / 2.0);
+// 1
+R123i.z = floatBitsToInt((intBitsToFloat(R1i.x) * 0.5 + intBitsToFloat(PV0i.w)));
+PV1i.z = R123i.z;
+// 2
+R5i.w = floatBitsToInt((intBitsToFloat(R9i.w) * 0.5 + intBitsToFloat(PV1i.z))/2.0);
+PV0i.w = R5i.w;
+// 3
+PV1i.x = ((1.0 > intBitsToFloat(PV0i.w))?int(0xFFFFFFFF):int(0x0));
+// 4
+R0i.y = ((R13i.w > 0)?(PV1i.x):(0));
+// 5
+predResult = (R0i.y != 0);
+activeMaskStack[2] = predResult;
+activeMaskStackC[3] = predResult == true && activeMaskStackC[2] == true;
+}
+else {
+activeMaskStack[2] = false;
+activeMaskStackC[3] = false;
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+PV0i.x = int(-1) + R13i.w;
+// 1
+PV1i.w = PV0i.x << 0x00000002;
+PS1i = floatBitsToInt(float(PV0i.x));
+// 2
+R0i.x = PV1i.w + 0x0000002c;
+R0i.y = PV1i.w + 0x0000002b;
+R0i.z = PV1i.w + 0x0000002a;
+R0i.w = PV1i.w + 0x0000002d;
+R4i.z = floatBitsToInt(roundEven(intBitsToFloat(PS1i)));
+PS0i = R4i.z;
+}
+if( activeMaskStackC[3] == true ) {
+R1i.xyzw = floatBitsToInt(uf_blockPS1[R0i.w].xyzw);
+R2i.xyzw = floatBitsToInt(uf_blockPS1[R0i.x].xyzw);
+R3i.xyzw = floatBitsToInt(uf_blockPS1[R0i.z].xyzw);
+R0i.xyzw = floatBitsToInt(uf_blockPS1[R0i.y].xyzw);
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R16i.x), intBitsToFloat(R2i.x)));
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R16i.x), intBitsToFloat(R1i.x)));
+// 1
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.y),intBitsToFloat(R2i.y)) + intBitsToFloat(PV0i.x)));
+PV1i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.y),intBitsToFloat(R1i.y)) + intBitsToFloat(PV0i.z)));
+PV1i.y = R123i.y;
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R16i.x), intBitsToFloat(R3i.x)));
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R16i.x), intBitsToFloat(R0i.x)));
+// 2
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R10i.z),intBitsToFloat(R1i.z)) + intBitsToFloat(PV1i.y)));
+PV0i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.y),intBitsToFloat(R3i.y)) + intBitsToFloat(PV1i.z)));
+PV0i.y = R123i.y;
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.y),intBitsToFloat(R0i.y)) + intBitsToFloat(PV1i.w)));
+PV0i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R10i.z),intBitsToFloat(R2i.z)) + intBitsToFloat(PV1i.x)));
+PV0i.w = R123i.w;
+// 3
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R10i.z),intBitsToFloat(R3i.z)) + intBitsToFloat(PV0i.y)));
+PV1i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R10i.z),intBitsToFloat(R0i.z)) + intBitsToFloat(PV0i.z)));
+PV1i.y = R123i.y;
+R127i.z = floatBitsToInt(intBitsToFloat(R2i.w) + intBitsToFloat(PV0i.w));
+PV1i.w = floatBitsToInt(intBitsToFloat(R1i.w) + intBitsToFloat(PV0i.x));
+// 4
+PV0i.x = floatBitsToInt(intBitsToFloat(R0i.w) + intBitsToFloat(PV1i.y));
+PV0i.w = floatBitsToInt(intBitsToFloat(R3i.w) + intBitsToFloat(PV1i.x));
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PV1i.w));
+// 5
+R4i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.w), intBitsToFloat(PS0i)));
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.z), intBitsToFloat(PS0i)));
+R4i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.x), intBitsToFloat(PS0i)));
+PS1i = R4i.y;
+// 6
+R4i.w = floatBitsToInt(intBitsToFloat(PV1i.y) + intBitsToFloat(0xbb03126f));
+R4i.w = clampFI32(R4i.w);
+}
+if( activeMaskStackC[3] == true ) {
+R4i.z = floatBitsToInt(texture(textureUnitPS8, vec4(intBitsToFloat(R4i.x),intBitsToFloat(R4i.y),intBitsToFloat(R4i.z),intBitsToFloat(R4i.w))));
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+backupReg0i = R5i.w;
+R5i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), intBitsToFloat(R4i.z)));
+}
+activeMaskStackC[2] = activeMaskStack[1] == true && activeMaskStackC[1] == true;
+if( activeMaskStackC[2] == true ) {
+R0i.x = floatBitsToInt(texture(textureUnitPS6, intBitsToFloat(R14i.xy)).x);
+R0i.y = floatBitsToInt(texture(textureUnitPS6, intBitsToFloat(R15i.xy)).x);
+R1i.x = floatBitsToInt(texture(textureUnitPS6, intBitsToFloat(R12i.xy)).x);
+R1i.y = floatBitsToInt(texture(textureUnitPS6, intBitsToFloat(R13i.xy)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+R127i.x = floatBitsToInt(intBitsToFloat(R6i.w) * intBitsToFloat(0x3f7eb852));
+PV0i.x = R127i.x;
+PV0i.y = floatBitsToInt(uf_blockPS1[16].x * intBitsToFloat(0x41a00000));
+R124i.z = floatBitsToInt(-(intBitsToFloat(R5i.w)) + 1.0);
+R127i.w = floatBitsToInt(uf_blockPS1[16].x * intBitsToFloat(0x3f555555));
+// 1
+backupReg0i = R0i.x;
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.x) + -(intBitsToFloat(R0i.y)));
+PV1i.y = floatBitsToInt(intBitsToFloat(PV0i.x) + -(intBitsToFloat(backupReg0i)));
+R127i.z = floatBitsToInt(intBitsToFloat(PV0i.y) * intBitsToFloat(0x3f8ba8d6));
+R127i.z = floatBitsToInt(intBitsToFloat(R127i.z) / 2.0);
+PV1i.w = floatBitsToInt(intBitsToFloat(PV0i.y) * intBitsToFloat(0x3fbc4580));
+PV1i.w = floatBitsToInt(intBitsToFloat(PV1i.w) / 2.0);
+R126i.z = floatBitsToInt(-(intBitsToFloat(R1i.x)) + intBitsToFloat(PV0i.x));
+PS1i = R126i.z;
+// 2
+backupReg0i = R127i.x;
+R127i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R127i.w)),intBitsToFloat(PV1i.y)) + 1.0));
+R127i.x = clampFI32(R127i.x);
+R127i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.w),intBitsToFloat(PV1i.x)) + 0.5));
+R127i.y = clampFI32(R127i.y);
+PV0i.y = R127i.y;
+R125i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.w),intBitsToFloat(PV1i.y)) + 0.5));
+R125i.z = clampFI32(R125i.z);
+PV0i.z = R125i.z;
+R126i.w = floatBitsToInt(-(intBitsToFloat(R1i.y)) + intBitsToFloat(backupReg0i));
+PV0i.w = R126i.w;
+R125i.w = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R127i.w)),intBitsToFloat(PV1i.x)) + 1.0));
+R125i.w = clampFI32(R125i.w);
+PS0i = R125i.w;
+// 3
+R126i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.z),intBitsToFloat(R126i.z)) + 0.5));
+R126i.x = clampFI32(R126i.x);
+PV1i.x = R126i.x;
+PV1i.y = floatBitsToInt(0.5 + -(intBitsToFloat(PV0i.y)));
+PV1i.z = floatBitsToInt(0.5 + -(intBitsToFloat(PV0i.z)));
+R124i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.z),intBitsToFloat(PV0i.w)) + 0.5));
+R124i.w = clampFI32(R124i.w);
+PV1i.w = R124i.w;
+R0i.w = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R127i.w)),intBitsToFloat(R126i.z)) + 1.0));
+R0i.w = clampFI32(R0i.w);
+PS1i = R0i.w;
+// 4
+backupReg0i = R127i.w;
+PV0i.x = floatBitsToInt(0.5 + -(intBitsToFloat(PV1i.x)));
+R126i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.z),intBitsToFloat(R127i.x)) + 0.5));
+PV0i.y = R126i.y;
+PV0i.z = floatBitsToInt(0.5 + -(intBitsToFloat(PV1i.w)));
+R127i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.y),intBitsToFloat(R125i.w)) + 0.5));
+PV0i.w = R127i.w;
+R125i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(backupReg0i)),intBitsToFloat(R126i.w)) + 1.0));
+R125i.y = clampFI32(R125i.y);
+PS0i = R125i.y;
+// 5
+PV1i.x = floatBitsToInt(intBitsToFloat(R127i.y) + -(intBitsToFloat(PV0i.y)));
+R127i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.z),intBitsToFloat(PS0i)) + 0.5));
+PV1i.y = R127i.y;
+PV1i.z = floatBitsToInt(intBitsToFloat(R125i.z) + -(intBitsToFloat(PV0i.w)));
+R126i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.x),intBitsToFloat(R0i.w)) + 0.5));
+PV1i.w = R126i.w;
+R3i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R124i.z),intBitsToFloat(R10i.w)) + intBitsToFloat(R5i.w)));
+PS1i = R3i.w;
+// 6
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.z),intBitsToFloat(R127i.x)) + intBitsToFloat(R127i.w)));
+PV0i.x = R123i.x;
+PV0i.y = floatBitsToInt(intBitsToFloat(R126i.x) + -(intBitsToFloat(PV1i.y)));
+PV0i.z = floatBitsToInt(intBitsToFloat(R124i.w) + -(intBitsToFloat(PV1i.w)));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.x),intBitsToFloat(R125i.w)) + intBitsToFloat(R126i.y)));
+PV0i.w = R123i.w;
+// 7
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.x) * intBitsToFloat(0x3e35e743));
+PV1i.y = floatBitsToInt(intBitsToFloat(PV0i.w) * intBitsToFloat(0x3e35e743));
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.z),intBitsToFloat(R125i.y)) + intBitsToFloat(R126i.w)));
+PV1i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.y),intBitsToFloat(R0i.w)) + intBitsToFloat(R127i.y)));
+PV1i.w = R123i.w;
+// 8
+R123i.x = floatBitsToInt((intBitsToFloat(PV1i.w) * intBitsToFloat(0x3e825397) + intBitsToFloat(PV1i.x)));
+PV0i.x = R123i.x;
+R123i.w = floatBitsToInt((intBitsToFloat(PV1i.z) * intBitsToFloat(0x3e825397) + intBitsToFloat(PV1i.y)));
+PV0i.w = R123i.w;
+// 9
+PV1i.z = floatBitsToInt(intBitsToFloat(PV0i.x) + intBitsToFloat(PV0i.w));
+// 10
+PV0i.y = floatBitsToInt(intBitsToFloat(PV1i.z) + intBitsToFloat(0xbedd476b));
+// 11
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.y) * intBitsToFloat(0x40c00000));
+PV1i.x = clampFI32(PV1i.x);
+// 12
+R1i.w = floatBitsToInt(-(intBitsToFloat(PV1i.x)) + 1.0);
+}
+activeMaskStack[1] = activeMaskStack[1] == false;
+activeMaskStackC[2] = activeMaskStack[1] == true && activeMaskStackC[1] == true;
+if( activeMaskStackC[2] == true ) {
+// 0
+R3i.w = R1i.w;
+}
+activeMaskStackC[1] = activeMaskStack[0] == true && activeMaskStackC[0] == true;
+if( activeMaskStackC[1] == true ) {
+// 0
+R0i.x = floatBitsToInt((intBitsToFloat(R10i.x) * intBitsToFloat(0x38d1b717) + 0.5));
+R0i.y = floatBitsToInt((intBitsToFloat(R11i.z) * intBitsToFloat(0x3903126f) + 0.5));
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R10i.y)));
+PV0i.z = floatBitsToInt(intBitsToFloat(PV0i.z) / 2.0);
+PV0i.w = R11i.x;
+PV0i.w = floatBitsToInt(intBitsToFloat(PV0i.w) / 2.0);
+R2i.z = R1i.w;
+PS0i = R2i.z;
+// 1
+R1i.x = floatBitsToInt(intBitsToFloat(PV0i.w) + 0.5);
+R1i.y = floatBitsToInt(intBitsToFloat(PV0i.z) + 0.5);
+R2i.w = 0x3f800000;
+}
+if( activeMaskStackC[1] == true ) {
+R0i.xyz = floatBitsToInt(textureLod(textureUnitPS15, intBitsToFloat(R0i.xy),0.0).xyz);
+R1i.y = floatBitsToInt(textureLod(textureUnitPS1, intBitsToFloat(R1i.xy),0.0).x);
+}
+if( activeMaskStackC[1] == true ) {
+// 0
+backupReg0i = R0i.x;
+backupReg1i = R0i.y;
+backupReg2i = R0i.z;
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(backupReg0i),intBitsToFloat(backupReg1i),intBitsToFloat(backupReg2i),-0.0),vec4(uf_blockPS6[42].x,uf_blockPS6[42].y,uf_blockPS6[42].z,0.0)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+R2i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R1i.y),-(intBitsToFloat(R11i.w))) + intBitsToFloat(R1i.y)));
+PS0i = R2i.y;
+// 1
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.x), intBitsToFloat(PV0i.x)));
+// 2
+R127i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.w), intBitsToFloat(PV1i.w)));
+PV0i.z = R127i.z;
+// 3
+PV1i.y = floatBitsToInt(intBitsToFloat(R3i.w) + -(intBitsToFloat(PV0i.z)));
+// 4
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.y),intBitsToFloat(R12i.w)) + intBitsToFloat(R127i.z)));
+PV0i.x = R123i.x;
+// 5
+R2i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.x),uf_blockPS10[3].z) + uf_blockPS10[1].y));
+R2i.x = clampFI32(R2i.x);
+}
+// export
+passPixelColor5 = vec4(intBitsToFloat(R2i.x), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w));
+}

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/patch_AspectRatio.asm
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/patch_AspectRatio.asm
@@ -1,0 +1,180 @@
+[BotW_AspectRatio_Shared]
+moduleMatches = 0xD91A406D,0x0F748D9C,0x9A61FF4C,0x8E3324A9,0xD71D859D,0x6FD41A61,0x9A2CA0C7,0x29DBB52A,0xFD091F9F,0xD472D8A5,0x6267BFD0
+
+.origin = codecave
+
+aspectRatio:
+.float ($width/$height)
+
+grassCulling: ; The grass is calculated in a weird way, but this fix seems to work. So for safety, only enable it for ultrawide resolutions.
+.float (($ultrawideHUDMode != 0)*(($gameWidth/$gameHeight) / ($width/$height))) + (($ultrawideHUDMode == 0)*1.0)
+
+
+[BotW_AspectRatio_V208]
+moduleMatches = 0x6267BFD0
+
+; rodata constants
+0x101BF8E8 = .float ($width/$height)
+0x1030A57C = .float ($width/$height)
+0x1036DD4C = .float ($width/$height)
+
+; 3D Rendering In Inventory (calculated every load)
+0x02E2C564 = lis r9, aspectRatio@ha
+0x02E2C578 = lfs f4, aspectRatio@l(r9)
+
+; 3D Rendering (calculated every frame)
+0x0386D01C = lis r28, aspectRatio@ha
+0x0386D020 = lfs f12, aspectRatio@l(r28)
+
+; Grass Culling (calculated every frame)
+0x035b0a30 = lis r5, grassCulling@ha
+0x035b0a38 = lfs f11, grassCulling@l(r5)
+
+; 2nd Type Of Grass Culling (calculated every frame)
+; Still kinda unsure how this should be calculated but it works
+0x1047BFB8 = .float (($ultrawideHUDMode != 0)*(120*0.5) + (($ultrawideHUDMode == 0)*(120)))
+
+
+[BotW_AspectRatio_V176V192]
+moduleMatches = 0xFD091F9F,0xD472D8A5
+
+; rodata constants
+0x101BF878 = .float $width/$height
+0x1030A3F4 = .float $width/$height
+0x1036DBDC = .float $width/$height
+
+; 3D Rendering In Inventory (calculated every load)
+0x02E2BFC8 = lis r9, aspectRatio@ha
+0x02E2BFDC = lfs f4, aspectRatio@l(r9)
+
+; 3D Rendering (calculated every frame)
+0x0386C314 = lis r28, aspectRatio@ha
+0x0386C318 = lfs f12, aspectRatio@l(r28)
+
+[BotW_AspectRatio_V160]
+moduleMatches = 0x9A2CA0C7
+
+; rodata constants
+0x101A8A70 = .float $width/$height
+0x102ECF88 = .float $width/$height
+0x1034F684 = .float $width/$height
+
+; 3D Rendering In Inventory (calculated every load)
+0x02D53CF4 = lis r9, aspectRatio@ha
+0x02D53D08 = lfs f4, aspectRatio@l(r9)
+
+; 3D Rendering (calculated every frame)
+0x0375AFF4 = lis r28, aspectRatio@ha
+0x0375AFF8 = lfs f12, aspectRatio@l(r28)
+
+[BotW_AspectRatio_V144]
+moduleMatches = 0x9A2CA0C7
+
+; rodata constants
+0x101A8A70 = .float $width/$height
+0x102ECFD0 = .float $width/$height
+0x1034F6CC = .float $width/$height
+
+; 3D Rendering In Inventory (calculated every load)
+0x02D53CF4 = lis r9, aspectRatio@ha
+0x02D53D08 = lfs f4, aspectRatio@l(r9)
+
+; 3D Rendering (calculated every frame)
+0x0375B128 = lis r28, aspectRatio@ha
+0x0375B12C = lfs f12, aspectRatio@l(r28)
+
+[BotW_AspectRatio_V112]
+moduleMatches = 0x6FD41A61
+
+; rodata constants
+0x1019F9A8 = .float $width/$height
+0x102DFB38 = .float $width/$height
+0x103414D4 = .float $width/$height
+
+; 3D Rendering In Inventory (calculated every load)
+0x02D2F404 = lis r9, aspectRatio@ha
+0x02D2F418 = lfs f4, aspectRatio@l(r9)
+
+; 3D Rendering (calculated every frame)
+0x03726E18 = lis r28, aspectRatio@ha
+0x03726E1C = lfs f12, aspectRatio@l(r28)
+
+[BotW_AspectRatio_V97]
+moduleMatches = 0xD71D859D
+
+; rodata constants
+0x1019F980 = .float $width/$height
+0x102DF8A0 = .float $width/$height
+0x1034122C = .float $width/$height
+
+; 3D Rendering In Inventory (calculated every load)
+0x02D2E65C = lis r9, aspectRatio@ha
+0x02D2E670 = lfs f4, aspectRatio@l(r9)
+
+; 3D Rendering (calculated every frame)
+0x03725CE8 = lis r28, aspectRatio@ha
+0x03725CEC = lfs f12, aspectRatio@l(r28)
+
+[BotW_AspectRatio_V80]
+moduleMatches = 0x8E3324A9
+
+; rodata constants
+0x1019A5A8 = .float $width/$height
+0x102D4E30 = .float $width/$height
+0x103391B4 = .float $width/$height
+
+; 3D Rendering In Inventory (calculated every load)
+0x02D056C8 = lis r9, aspectRatio@ha
+0x02D056DC = lfs f4, aspectRatio@l(r9)
+
+; 3D Rendering (calculated every frame)
+0x036D0324 = lis r28, aspectRatio@ha
+0x036D0328 = lfs f12, aspectRatio@l(r28)
+
+[BotW_AspectRatio_V64]
+moduleMatches = 0x9A61FF4C
+
+; rodata constants
+0x10198250 = .float $width/$height
+0x102CD450 = .float $width/$height
+0x1033182C = .float $width/$height
+
+; 3D Rendering In Inventory (calculated every load)
+0x02CFD900 = lis r9, aspectRatio@ha
+0x02CFD914 = lfs f4, aspectRatio@l(r9)
+
+; 3D Rendering (calculated every frame)
+0x036AEF04 = lis r28, aspectRatio@ha
+0x036AEF08 = lfs f12, aspectRatio@l(r28)
+
+[BotW_AspectRatio_V48]
+moduleMatches = 0x0F748D9C
+
+; rodata constants
+0x10197FC0 = .float $width/$height
+0x102CCFC8 = .float $width/$height
+0x103313A4 = .float $width/$height
+
+; 3D Rendering In Inventory (calculated every load)
+0x02CFC2CC = lis r9, aspectRatio@ha
+0x02CFC2E0 = lfs f4, aspectRatio@l(r9)
+
+; 3D Rendering (calculated every frame)
+0x036AD81C = lis r28, aspectRatio@ha
+0x036AD820 = lfs f12, aspectRatio@l(r28)
+
+[BotW_AspectRatio_V33]
+moduleMatches = 0xD91A406D
+
+; rodata constants
+0x10197FC0 = .float $width/$height
+0x102CCFC0 = .float $width/$height
+0x10331374 = .float $width/$height
+
+; 3D Rendering In Inventory (calculated every load)
+0x02CFC260 = lis r9, aspectRatio@ha
+0x02CFC274 = lfs f4, aspectRatio@l(r9)
+
+; 3D Rendering (calculated every frame)
+0x036AD410 = lis r28, aspectRatio@ha
+0x036AD414 = lfs f12, aspectRatio@l(r28)

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/patch_GUIAspectRatio.asm
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/patch_GUIAspectRatio.asm
@@ -1,0 +1,2904 @@
+[BotW_GUIAspectRatio_V208]
+moduleMatches = 0x6267BFD0
+
+.origin = codecave
+
+const_AspectRatio:
+.float ($gameWidth/$gameHeight)/($width/$height)
+
+const_AspectRatioHalf:
+.float (($gameWidth/$gameHeight)/($width/$height))/2
+
+const_ReverseAspectRatio:
+.float ($width/$height)/($gameWidth/$gameHeight)
+
+const_ReverseAspectRatio2x:
+.float (($width/$height)/($gameWidth/$gameHeight))*2
+
+const_PaddingLeftSide:
+.float (($gameWidth/$gameHeight)/($width/$height)) * ((($width/($height/720))/2) - 640) * (-1)
+
+const_PaddingRightSide:
+.float (($gameWidth/$gameHeight)/($width/$height)) * ((($width/($height/720))/2) - 640)
+
+const_AltPaddingLeftSide:
+.float (($gameWidth/$gameHeight)/($width/$height)) * (($width/2) - 640) * (-1)
+
+const_AltPaddingRightSide:
+.float (($gameWidth/$gameHeight)/($width/$height)) * (($width/2) - 640)
+
+
+newLineFormatScreen:
+.string "Loading screen %s...%c"
+newLineFormatPanes:
+.string "    Pane: %s...%c"
+newLineCharacter:
+.int 10
+
+copyScreenString:
+.string "PaAppDungeonBtnNextMoveFinalDLC_00" ; longest .blyt name
+.align 4
+copyScreenStringLen:
+.int 34
+
+copySubPanelString:
+.string "PaAppDungeonBtnNextMoveFinalDLC_00" ; longest .blyt name
+.align 4
+copySubPanelStringLen:
+.int 34
+
+; free registers = r12, r10, r9, r11, r8 maybe
+; r31 has the name of the pane at an offset at 0x80
+_scalePaneGUI:
+mflr r0
+
+li r10, $ultrawideHUDMode
+cmpwi r10, 0
+beq exitScale
+
+; Log currently loaded pane to register if logging is enabled
+li r10, $enableUltrawideDebugLogging
+cmpwi r10, 2
+blt skipPaneLogging
+
+mr r10, r3
+mr r11, r4
+mr r12, r5
+crxor 4*cr1+eq, 4*cr1+eq, 4*cr1+eq
+lis r3, newLineFormatPanes@ha
+addi r3, r3, newLineFormatPanes@l
+addi r4, r31, 0x80
+lis r5, newLineCharacter@ha
+lwz r5, newLineCharacter@l(r5)
+bl import.coreinit.OSReport
+mr r3, r10
+mr r4, r11
+mr r5, r12
+
+skipPaneLogging:
+
+; ------------------------------------------------------------------------------------------
+; Store whether there's a subpanel name
+
+addi r5, r31, 0x80
+
+lbz r11, 0x0(r5)
+cmpwi r11, 0x50
+bne checkScreenNames
+lbz r11, 0x1(r5)
+cmpwi r11, 0x61
+bne checkScreenNames
+
+lis r11, copySubPanelStringLen@ha
+lwz r11, copySubPanelStringLen@l(r11)
+lis r12, copySubPanelString@ha
+addi r12, r12, copySubPanelString@l
+
+copySubPanelLoop:
+lbzx r10, r5, r11
+stbx r10, r12, r11
+addi r11, r11, -1
+cmpwi r11, -1
+bne copySubPanelLoop
+
+
+; ------------------------------------------------------------------------------------------
+; Check which screen is getting loaded by using the copied screen name
+
+checkScreenNames:
+lis r5, copyScreenString@ha
+addi r5, r5, copyScreenString@l
+
+lis r10, scr_BootUp_00@ha
+addi r10, r10, scr_BootUp_00@l
+bla _compareString
+beq scaleInOutToCenter
+
+lis r10, scr_ChangeController_00@ha
+addi r10, r10, scr_ChangeController_00@l
+bla _compareString
+beq scaleInOutScreenToRightSide
+
+lis r10, scr_ChangeControllerDRC_00@ha
+addi r10, r10, scr_ChangeControllerDRC_00@l
+bla _compareString
+beq scaleInOutScreenToRightSide
+
+lis r10, scr_GamePadBG_00@ha ; Can't be scaled properly, even when scaling individually
+addi r10, r10, scr_GamePadBG_00@l
+bla _compareString
+beq scaleRootToCenter
+
+lis r10, scr_Title_00@ha
+addi r10, r10, scr_Title_00@l
+bla _compareString
+beq scaleTitlePanes
+
+lis r10, scr_SystemWindow_01@ha
+addi r10, r10, scr_SystemWindow_01@l
+bla _compareString
+beq scaleSystemWindowPanes
+
+lis r10, scr_AppSystemWindow_00@ha
+addi r10, r10, scr_AppSystemWindow_00@l
+bla _compareString
+beq scaleAppSystemWindowPanes
+
+lis r10, scr_AppSystemWindowNoBtn_00@ha
+addi r10, r10, scr_AppSystemWindowNoBtn_00@l
+bla _compareString
+beq scaleInOutScreenToRightSide
+
+lis r10, scr_OptionWindow_00@ha
+addi r10, r10, scr_OptionWindow_00@l
+bla _compareString
+beq scaleOptionsMenuPanes
+
+lis r10, scr_AmiiboWindow_00@ha
+addi r10, r10, scr_AmiiboWindow_00@l
+bla _compareString
+beq scaleInOutToCenter
+
+lis r10, scr_Fade@ha
+addi r10, r10, scr_Fade@l
+bla _compareString
+beq scaleLoadingPanes
+
+lis r10, scr_GameOver_00@ha
+addi r10, r10, scr_GameOver_00@l
+bla _compareString
+beq scaleGameOverPanes
+
+lis r10, scr_FadeStatus_00@ha
+addi r10, r10, scr_FadeStatus_00@l
+bla _compareString
+beq scaleLoadingStatusPanes
+
+lis r10, scr_Skip_00@ha
+addi r10, r10, scr_Skip_00@l
+bla _compareString
+beq scaleSkipButtonPanes
+
+lis r10, scr_LoadSaveIcon_00@ha
+addi r10, r10, scr_LoadSaveIcon_00@l
+bla _compareString
+beq scaleLoadSaveIconPanes
+
+lis r10, scr_MainScreen_00@ha
+addi r10, r10, scr_MainScreen_00@l
+bla _compareString
+beq scaleMainScreenPanes
+
+lis r10, scr_MainDungeon_00@ha
+addi r10, r10, scr_MainDungeon_00@l
+bla _compareString
+beq scaleMainDungeonPanes
+
+lis r10, scr_MainScreenMS_00@ha
+addi r10, r10, scr_MainScreenMS_00@l
+bla _compareString
+beq scaleMainScreenMasterSwordPanes
+
+lis r10, scr_WolfLinkHeartGauge_00@ha
+addi r10, r10, scr_WolfLinkHeartGauge_00@l
+bla _compareString
+beq scaleWolfLinkHeartPanes
+
+lis r10, scr_Rupee_00@ha
+addi r10, r10, scr_Rupee_00@l
+bla _compareString
+beq scaleSimpleItemGetPanes
+
+lis r10, scr_AkashNum_00@ha
+addi r10, r10, scr_AkashNum_00@l
+bla _compareString
+beq scaleSimpleItemGetPanes
+
+lis r10, scr_KologNum_00@ha
+addi r10, r10, scr_KologNum_00@l
+bla _compareString
+beq scaleSimpleItemGetPanes
+
+lis r10, scr_MamoNum_00@ha
+addi r10, r10, scr_MamoNum_00@l
+bla _compareString
+beq scaleSimpleItemGetPanes
+
+lis r10, scr_KeyNum_00@ha
+addi r10, r10, scr_KeyNum_00@l
+bla _compareString
+beq scaleSimpleItemGetPanes
+
+lis r10, scr_Time_00@ha
+addi r10, r10, scr_Time_00@l
+bla _compareString
+beq scaleSimpleItemGetPanes
+
+lis r10, scr_MainScreen3D_00@ha
+addi r10, r10, scr_MainScreen3D_00@l
+bla _compareString
+beq scaleMainScreen3DPanes
+
+lis r10, scr_MainShortCut_00@ha
+addi r10, r10, scr_MainShortCut_00@l
+bla _compareString
+beq scaleMainShortCutPanes
+
+lis r10, scr_MainHorse_00@ha
+addi r10, r10, scr_MainHorse_00@l
+bla _compareString
+beq scaleHorseStaminaPanes
+
+lis r10, scr_MainHardMode_00@ha
+addi r10, r10, scr_MainHardMode_00@l
+bla _compareString
+beq scaleMainHardModePanes
+
+lis r10, scr_PauseMenu_00@ha
+addi r10, r10, scr_PauseMenu_00@l
+bla _compareString
+beq scalePauseMenuPanes
+
+lis r10, scr_AppHome_00@ha
+addi r10, r10, scr_AppHome_00@l
+bla _compareString
+beq scalePauseHomePanes
+
+lis r10, scr_AppTool_00@ha
+addi r10, r10, scr_AppTool_00@l
+bla _compareString
+beq scalePauseRunePanes
+
+lis r10, scr_AppAlbum_00@ha
+addi r10, r10, scr_AppAlbum_00@l
+bla _compareString
+beq scalePauseAlbumPanes
+
+lis r10, scr_AppPictureBook_00@ha
+addi r10, r10, scr_AppPictureBook_00@l
+bla _compareString
+beq scalePausePictureBookPanes
+
+lis r10, scr_SystemWindow_00@ha
+addi r10, r10, scr_SystemWindow_00@l
+bla _compareString
+beq scaleSystemWindowInventoryPanes
+
+lis r10, scr_ControllerWindow_00@ha
+addi r10, r10, scr_ControllerWindow_00@l
+bla _compareString
+beq scalePauseMenuAbilityControlsPanes
+
+lis r10, scr_PauseMenuBG_00@ha
+addi r10, r10, scr_PauseMenuBG_00@l
+bla _compareString
+beq scalePauseMenuBGPanes
+
+lis r10, scr_PauseMenuInfo_00@ha
+addi r10, r10, scr_PauseMenuInfo_00@l
+bla _compareString
+beq scalePauseMenuInfoPanes
+
+lis r10, scr_PauseMenuRecipe_00@ha
+addi r10, r10, scr_PauseMenuRecipe_00@l
+bla _compareString
+beq scaleTopInOutToCenterAndPos
+
+lis r10, scr_PauseMenuMantan_00@ha
+addi r10, r10, scr_PauseMenuMantan_00@l
+bla _compareString
+beq scaleTopInOutToCenterAndPos
+
+lis r10, scr_ShopHorse_00@ha
+addi r10, r10, scr_ShopHorse_00@l
+bla _compareString
+beq scaleShopHorsePanes
+
+lis r10, scr_ShopBtnList5_00@ha
+addi r10, r10, scr_ShopBtnList5_00@l
+bla _compareString
+beq scaleShop05Panes
+
+lis r10, scr_ShopBtnList15_00@ha
+addi r10, r10, scr_ShopBtnList15_00@l
+bla _compareString
+beq scaleTopInOutToCenter
+
+lis r10, scr_ShopBtnList20_00@ha
+addi r10, r10, scr_ShopBtnList20_00@l
+bla _compareString
+beq scaleShop20Panes
+
+lis r10, scr_ShopInfo_00@ha
+addi r10, r10, scr_ShopInfo_00@l
+bla _compareString
+beq scaleTopInOutToCenter
+
+lis r10, scr_AppMap_00@ha
+addi r10, r10, scr_AppMap_00@l
+bla _compareString
+beq scaleMapPanes
+
+lis r10, scr_AppMapDungeon_00@ha
+addi r10, r10, scr_AppMapDungeon_00@l
+bla _compareString
+beq scaleDungeonMapPanes
+
+lis r10, scr_AppCamera_00@ha
+addi r10, r10, scr_AppCamera_00@l
+bla _compareString
+beq scaleCameraPanes
+
+lis r10, scr_DoCommand_00@ha
+addi r10, r10, scr_DoCommand_00@l
+bla _compareString
+beq scaleDoCommandPanes
+
+lis r10, scr_PickUp_00@ha
+addi r10, r10, scr_PickUp_00@l
+bla _compareString
+beq scalePickupPanes
+
+lis r10, scr_SousaGuide_00@ha
+addi r10, r10, scr_SousaGuide_00@l
+bla _compareString
+beq scaleRuneGuidePanes
+
+lis r10, scr_MessageDialog@ha
+addi r10, r10, scr_MessageDialog@l
+bla _compareString
+beq scaleMessageDialogPanes
+
+lis r10, scr_MessageSp_00@ha
+addi r10, r10, scr_MessageSp_00@l
+bla _compareString
+beq scaleMessageSpPanes
+
+lis r10, str_MessageSp_00_NoTop@ha
+addi r10, r10, str_MessageSp_00_NoTop@l
+bla _compareString
+beq scaleMessageSpPanes
+
+lis r10, scr_MessageGet_00@ha
+addi r10, r10, scr_MessageGet_00@l
+bla _compareString
+beq scaleMessageGetPanes
+
+lis r10, scr_Message3D_00@ha
+addi r10, r10, scr_Message3D_00@l
+bla _compareString
+beq scaleMessage3DPanes
+
+lis r10, scr_DemoMessage@ha
+addi r10, r10, scr_DemoMessage@l
+bla _compareString
+beq scaleInOutToCenter
+
+lis r10, scr_DemoMessage_00@ha
+addi r10, r10, scr_DemoMessage_00@l
+bla _compareString
+beq scaleInOutToCenter
+
+lis r10, scr_DemoName@ha
+addi r10, r10, scr_DemoName@l
+bla _compareString
+beq scaleInOutToCenter
+
+lis r10, scr_DemoName_00@ha
+addi r10, r10, scr_DemoName_00@l
+bla _compareString
+beq scaleInOutToCenter
+
+lis r10, scr_DemoNameEnemy@ha
+addi r10, r10, scr_DemoNameEnemy@l
+bla _compareString
+beq scaleDemoNameEnemyPanes
+
+lis r10, scr_DemoNameEnemy_00@ha
+addi r10, r10, scr_DemoNameEnemy_00@l
+bla _compareString
+beq scaleDemoNameEnemyPanes
+
+lis r10, scr_LastComplete_00@ha
+addi r10, r10, scr_LastComplete_00@l
+bla _compareString
+beq scaleLastCompletePanes
+
+lis r10, scr_StaffRoll_00@ha
+addi r10, r10, scr_StaffRoll_00@l
+bla _compareString
+beq scaleCreditPanes
+
+lis r10, scr_StaffRollDLC_00@ha
+addi r10, r10, scr_StaffRollDLC_00@l
+bla _compareString
+beq scaleDLCCreditPanes
+
+lis r10, scr_Thanks_00@ha
+addi r10, r10, scr_Thanks_00@l
+bla _compareString
+beq scaleThanksPanes
+
+lis r10, scr_End_00@ha
+addi r10, r10, scr_End_00@l
+bla _compareString
+beq scaleInOutToCenter
+
+lis r10, scr_HardMode_00@ha
+addi r10, r10, scr_HardMode_00@l
+bla _compareString
+beq scaleInOutToCenter
+
+lis r10, scr_DLCWindow_00@ha
+addi r10, r10, scr_DLCWindow_00@l
+bla _compareString
+beq scaleDLCWindowPanes
+
+lis r10, scr_BoxCursorTV@ha
+addi r10, r10, scr_BoxCursorTV@l
+bla _compareString
+beq scaleCursorPanes
+
+lis r10, scr_KeyBoradTextArea_00@ha
+addi r10, r10, scr_KeyBoradTextArea_00@l
+bla _compareString
+beq scaleInOutToCenter
+
+lis r10, scr_GameTitle_00@ha
+addi r10, r10, scr_GameTitle_00@l
+bla _compareString
+beq scaleGameTitlePanes
+
+lis r10, scr_HardModeTextDLC_00@ha
+addi r10, r10, scr_HardModeTextDLC_00@l
+bla _compareString
+beq scaleInOutScreenToLeftSide
+
+lis r10, scr_MessageTipsRunTime_00@ha
+addi r10, r10, scr_MessageTipsRunTime_00@l
+bla _compareString
+beq scaleRuntimeMessagePanes
+
+lis r10, scr_MessageTips_00@ha
+addi r10, r10, scr_MessageTips_00@l
+bla _compareString
+beq scaleMessageTipsPanes
+
+lis r10, scr_OPtext_00@ha
+addi r10, r10, scr_OPtext_00@l
+bla _compareString
+beq scaleInOutToCenter
+
+lis r10, scr_ChallengeWin_00@ha
+addi r10, r10, scr_ChallengeWin_00@l
+bla _compareString
+beq scaleInOutScreenToRightSide
+
+lis r10, scr_EnergyMeterDLC_00@ha
+addi r10, r10, scr_EnergyMeterDLC_00@l
+bla _compareString
+beq scaleEnergyMeterDLCPanes
+
+; lis r10, scr_Message_00@ha
+; addi r10, r10, scr_Message_00@l
+; bla _compareString
+; beq scaleInOutToCenter
+
+; If nothing matched, exit without setting the size or position of this pane
+b exitScale
+
+; ------------------------------------------------------------------------------------------
+; Methods used to scale a specific pane type
+
+scaleMainScreenPanes:
+lis r5, copySubPanelString@ha
+addi r5, r5, copySubPanelString@l
+lis r10, str_Pa_ArrowPointer_00@ha
+addi r10, r10, str_Pa_ArrowPointer_00@l
+bla _compareString
+beq scaleInOutToCenter
+lis r10, str_Pa_ItemPointer_00@ha
+addi r10, r10, str_Pa_ItemPointer_00@l
+bla _compareString
+beq scaleMainScreenRunePointingPanes
+lis r10, str_Pa_ThrowingPointer_00@ha
+addi r10, r10, str_Pa_ThrowingPointer_00@l
+bla _compareString
+beq scaleInOutToCenter
+lis r10, str_Pa_CameraPointer_00@ha
+addi r10, r10, str_Pa_CameraPointer_00@l
+bla _compareString
+beq scaleMainScreenCameraPointerPanes
+lis r10, str_Pa_BtnZR_00@ha
+addi r10, r10, str_Pa_BtnZR_00@l
+bla _compareString
+beq scaleMainScreenScopeFramePanes
+lis r10, str_Pa_Deco_00@ha
+addi r10, r10, str_Pa_Deco_00@l
+bla _compareString
+beq scaleMainScreenScopeFramePanes
+lis r10, str_Pa_Gauge_00@ha
+addi r10, r10, str_Pa_Gauge_00@l
+bla _compareString
+beq scaleMainScreenGaugePanes
+
+lis r10, str_Pa_Time_00@ha
+addi r10, r10, str_Pa_Time_00@l
+bla _compareString
+beq scaleMainScreenTimePanes
+lis r10, str_Pa_Sensor_00@ha
+addi r10, r10, str_Pa_Sensor_00@l
+bla _compareString
+beq scaleSensorMeterPanes
+lis r10, str_Pa_SoundGauge_00@ha
+addi r10, r10, str_Pa_SoundGauge_00@l
+bla _compareString
+beq scaleSoundMeterPanes
+lis r10, str_Pa_TempMeter_00@ha
+addi r10, r10, str_Pa_TempMeter_00@l
+bla _compareString
+beq scaleTempMeterPanes
+lis r10, str_Pa_Weather_00@ha
+addi r10, r10, str_Pa_Weather_00@l
+bla _compareString
+beq scaleMainScreenWeatherPanes
+
+lis r10, str_Pa_Information_00@ha
+addi r10, r10, str_Pa_Information_00@l
+bla _compareString
+beq scaleMainScreenInformationTextPanes
+lis r10, str_Pa_LocationName_00@ha
+addi r10, r10, str_Pa_LocationName_00@l
+bla _compareString
+beq scaleMainScreenLocationTextPanes
+lis r10, str_Pa_LocationNameS_00@ha
+addi r10, r10, str_Pa_LocationNameS_00@l
+bla _compareString
+beq scaleMainScreenSmallLocationTextPanes
+lis r10, str_Pa_QuestName_00@ha
+addi r10, r10, str_Pa_QuestName_00@l
+bla _compareString
+beq scaleMainScreenQuestTextPanes
+lis r10, str_Pa_BossGauge_00@ha
+addi r10, r10, str_Pa_BossGauge_00@l
+bla _compareString
+beq scaleMainScreenBossGaugePanes
+
+addi r5, r31, 0x80
+lis r10, str_N_State_00@ha
+addi r10, r10, str_N_State_00@l
+bla _compareString
+beq scalePaneToLeftSideIf
+lis r10, str_Pa_SinJu_00@ha
+addi r10, r10, str_Pa_SinJu_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+lis r10, str_Pa_SinJu_01@ha
+addi r10, r10, str_Pa_SinJu_01@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+lis r10, str_Pa_SinJu_02@ha
+addi r10, r10, str_Pa_SinJu_02@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+lis r10, str_Pa_SinJu_03@ha
+addi r10, r10, str_Pa_SinJu_03@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+lis r10, str_Pa_SinJu_03@ha
+addi r10, r10, str_Pa_SinJu_03@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+b exitScale
+
+const_SensorsOffset:
+.float 392.0
+scaleSoundMeterPanes:
+addi r5, r31, 0x80
+lis r10, const_SensorsOffset@ha
+lfs f12, const_SensorsOffset@l(r10)
+lis r10, str_N_InOut_00@ha
+addi r10, r10, str_N_InOut_00@l
+bla _compareString
+beq scalePaneAndKeepCustomPosIf
+b exitScale
+scaleSensorMeterPanes:
+addi r5, r31, 0x80
+lis r10, const_SensorsOffset@ha
+lfs f12, const_SensorsOffset@l(r10)
+lis r10, str_N_InOut_00@ha
+addi r10, r10, str_N_InOut_00@l
+bla _compareString
+beq scalePaneAndKeepCustomPosIf
+b exitScale
+scaleTempMeterPanes:
+addi r5, r31, 0x80
+lis r10, const_SensorsOffset@ha
+lfs f12, const_SensorsOffset@l(r10)
+lis r10, str_N_InOut_00@ha
+addi r10, r10, str_N_InOut_00@l
+bla _compareString
+beq scalePaneAndKeepCustomPosIf
+b exitScale
+const_TimeOffset:
+.float (($ultrawideHUDMode == 1) * (342*0.85)) + (($ultrawideHUDMode == 2)*(342*(1/0.85)))
+scaleMainScreenTimePanes:
+addi r5, r31, 0x80
+lis r10, const_TimeOffset@ha
+lfs f12, const_TimeOffset@l(r10)
+lis r10, str_N_All_00@ha
+addi r10, r10, str_N_All_00@l
+bla _compareString
+beq scalePaneAndKeepCustomPosIf
+b exitScale
+scaleMainScreenWeatherPanes:
+addi r5, r31, 0x80
+lis r10, str_N_InOut_00@ha
+addi r10, r10, str_N_InOut_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+b exitScale
+scaleMainScreenInformationTextPanes:
+addi r5, r31, 0x80
+lis r10, str_Pa_Information_00@ha
+addi r10, r10, str_Pa_Information_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+scaleMainScreenLocationTextPanes:
+addi r5, r31, 0x80
+lis r10, str_Pa_LocationName_00@ha
+addi r10, r10, str_Pa_LocationName_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+scaleMainScreenQuestTextPanes:
+addi r5, r31, 0x80
+lis r10, str_Pa_QuestName_00@ha
+addi r10, r10, str_Pa_QuestName_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_P_Base_01@ha
+addi r10, r10, str_P_Base_01@l
+bla _compareString
+beq scalePaneReverse
+lis r10, str_P_Base_00@ha
+addi r10, r10, str_P_Base_00@l
+bla _compareString
+beq scalePaneReverse
+b exitScale
+
+scaleMainScreenSmallLocationTextPanes:
+addi r5, r31, 0x80
+lis r10, str_Pa_LocationNameS_00@ha
+addi r10, r10, str_Pa_LocationNameS_00@l
+bla _compareString
+beq scalePaneToLeftSideIf
+b exitScale
+scaleMainScreenBossGaugePanes:
+addi r5, r31, 0x80
+lis r10, str_N_All_00@ha
+addi r10, r10, str_N_All_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+scaleMainScreenGaugePanes:
+addi r5, r31, 0x80
+lis r10, str_N_All_00@ha
+addi r10, r10, str_N_All_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+scaleMainScreenCameraPointerPanes:
+addi r5, r31, 0x80
+lis r10, str_N_InOut_01@ha
+addi r10, r10, str_N_InOut_01@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Dungeon_00@ha
+addi r10, r10, str_N_Dungeon_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+scaleMainScreenScopeFramePanes:
+addi r5, r31, 0x80
+lis r10, str_N_TimeLineDemo_00@ha
+addi r10, r10, str_N_TimeLineDemo_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_IconSeek_00@ha
+addi r10, r10, str_N_IconSeek_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+scaleMainScreenRunePointingPanes:
+addi r5, r31, 0x80
+lis r10, str_N_SunLight_00@ha
+addi r10, r10, str_N_SunLight_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleMainDungeonPanes:
+addi r5, r31, 0x80
+lis r10, str_Pa_LocationNameS_00@ha
+addi r10, r10, str_Pa_LocationNameS_00@l
+bla _compareString
+beq scalePaneToLeftSideIf
+lis r10, str_Pa_Message_00@ha
+addi r10, r10, str_Pa_Message_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_Pa_Title_00@ha
+addi r10, r10, str_Pa_Title_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleMainDungeonLocationNames:
+addi r5, r31, 0x80
+lis r10, str_N_In_00@ha
+addi r10, r10, str_N_In_00@l
+bla _compareString
+beq scalePaneToLeftSideIf
+b exitScale
+
+scaleSpiritOrbPanes:
+addi r5, r31, 0x80
+lis r10, str_W_Base_00@ha
+addi r10, r10, str_W_Base_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+lis r10, str_T_Time_00@ha
+addi r10, r10, str_T_Time_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+b exitScale
+
+scaleSimpleItemGetPanes:
+lis r5, copySubPanelString@ha
+lbz r5, copySubPanelString@l(r5)
+cmpwi r5, 0
+beq scaleItemGetNoPanes
+
+continueSimpleItemGetPanes:
+
+lis r5, copySubPanelString@ha
+addi r5, r5, copySubPanelString@l
+lis r10, scr_PaPlusMinus_00@ha
+addi r10, r10, scr_PaPlusMinus_00@l
+bla _compareString
+beq scaleItemGetPlusMinusPanes
+
+addi r5, r31, 0x80
+lis r10, str_W_Base_00@ha
+addi r10, r10, str_W_Base_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+lis r10, str_T_Num_00@ha
+addi r10, r10, str_T_Num_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+lis r10, str_T_Time_00@ha
+addi r10, r10, str_T_Time_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+lis r10, str_T_Rupee_00@ha
+addi r10, r10, str_T_Rupee_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+lis r10, str_T_KeyNum_00@ha
+addi r10, r10, str_T_KeyNum_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+lis r10, str_P_Icon_00@ha
+addi r10, r10, str_P_Icon_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+lis r10, str_N_Icon_00@ha
+addi r10, r10, str_N_Icon_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+lis r10, str_P_KologNuts_00@ha
+addi r10, r10, str_P_KologNuts_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+b exitScale
+
+const_ItemGetPlusMinusOffset:
+.float -514.0
+scaleItemGetPlusMinusPanes:
+addi r5, r31, 0x80
+lis r10, const_ItemGetPlusMinusOffset@ha
+lfs f12, const_ItemGetPlusMinusOffset@l(r10)
+lis r10, str_N_InOut_00@ha
+addi r10, r10, str_N_InOut_00@l
+bla _compareString
+beq scalePaneAndKeepCustomPosIf
+b exitScale
+
+scaleItemGetNoPanes:
+addi r5, r31, 0x80
+lis r10, str_N_Capture_00@ha
+addi r10, r10, str_N_Capture_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+b continueSimpleItemGetPanes
+
+scaleWolfLinkHeartPanes:
+lis r5, copySubPanelString@ha
+addi r5, r5, copySubPanelString@l
+
+lis r10, str_Pa_HeartGauge_00@ha
+addi r10, r10, str_Pa_HeartGauge_00@l
+bla _compareString
+beq scaleWolfLinkHeartsPanes
+
+lis r5, copySubPanelString@ha
+lbz r5, copySubPanelString@l(r5)
+cmpwi r5, 0
+beq scaleWolfLinkHeartNoPanes
+b exitScale
+
+scaleWolfLinkHeartNoPanes:
+addi r5, r31, 0x80
+lis r10, str_P_Sh_00@ha
+addi r10, r10, str_P_Sh_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+lis r10, str_P_Illust_00@ha
+addi r10, r10, str_P_Illust_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+b exitScale
+
+const_WolfHeartOffset:
+.float -468.0
+scaleWolfLinkHeartsPanes:
+addi r5, r31, 0x80
+lis r10, str_T_Name_00@ha
+addi r10, r10, str_T_Name_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+lis r10, const_WolfHeartOffset@ha
+lfs f12, const_WolfHeartOffset@l(r10)
+lis r10, str_N_InOut_00@ha
+addi r10, r10, str_N_InOut_00@l
+bla _compareString
+beq scalePaneAndKeepCustomPosIf
+b exitScale
+
+scaleMainScreenMasterSwordPanes:
+lis r5, copySubPanelString@ha
+lbz r5, copySubPanelString@l(r5)
+cmpwi r5, 0
+beq scaleMainScreenMasterSwordNoPanes
+b exitScale
+
+scaleMainScreenMasterSwordNoPanes:
+addi r5, r31, 0x80
+lis r10, str_N_InOut_00@ha
+addi r10, r10, str_N_InOut_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleMainScreen3DPanes:
+lis r5, copySubPanelString@ha
+addi r5, r5, copySubPanelString@l
+
+lis r10, str_Pa_NoticeItem_00@ha
+addi r10, r10, str_Pa_NoticeItem_00@l
+bla _compareString
+beq scaleMainScreen3DPickupPanes
+lis r10, str_Pa_StaminaGauge_00@ha
+addi r10, r10, str_Pa_StaminaGauge_00@l
+bla _compareString
+beq scaleMainScreen3DStaminaPanes
+lis r10, str_Pa_EnemyMark_00@ha
+addi r10, r10, str_Pa_EnemyMark_00@l
+bla _compareString
+beq scaleMainScreen3DEnemyNoticePanes
+lis r10, str_Pa_EnemyGauge_00@ha
+addi r10, r10, str_Pa_EnemyGauge_00@l
+bla _compareString
+beq scaleMainScreen3DEnemyGaugePanes
+lis r10, str_Pa_NoticeZ_00@ha
+addi r10, r10, str_Pa_NoticeZ_00@l
+bla _compareString
+beq scaleInOutToCenter
+lis r10, str_Pa_BonusStaminaGauge_00@ha
+addi r10, r10, str_Pa_BonusStaminaGauge_00@l
+bla _compareString
+beq scaleMainScreen3DBonusStaminaPanes
+b exitScale
+
+scaleMainScreen3DStaminaPanes:
+addi r5, r31, 0x80
+lis r10, str_N_All_00@ha
+addi r10, r10, str_N_All_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+scaleMainScreen3DBonusStaminaPanes:
+addi r5, r31, 0x80
+lis r10, str_N_Size_05@ha
+addi r10, r10, str_N_Size_05@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+scaleMainScreen3DPickupPanes:
+addi r5, r31, 0x80
+lis r10, str_N_Capture_00@ha
+addi r10, r10, str_N_Capture_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_ModeItem_00@ha
+addi r10, r10, str_N_ModeItem_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+scaleMainScreen3DEnemyNoticePanes:
+addi r5, r31, 0x80
+lis r10, str_N_Change_00@ha
+addi r10, r10, str_N_Change_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Change_01@ha
+addi r10, r10, str_N_Change_01@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+scaleMainScreen3DEnemyGaugePanes:
+addi r5, r31, 0x80
+lis r10, str_N_Gauge_00@ha
+addi r10, r10, str_N_Gauge_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleHorseStaminaPanes:
+addi r5, r31, 0x80
+lis r10, str_N_ExUse_01@ha
+addi r10, r10, str_N_ExUse_01@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleMainShortCutPanes:
+addi r5, r31, 0x80
+lis r10, str_N_MainAll_00@ha ; scales the DPAD guide on the right
+addi r10, r10, str_N_MainAll_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+lis r10, str_N_Cut_00@ha ; scales the item/rune selection bar
+addi r10, r10, str_N_Cut_00@l
+bla _compareString
+beq scalePaneNormal
+
+lis r10, str_N_Capture_00@ha
+addi r10, r10, str_N_Capture_00@l
+bla _compareString
+beq scalePaneAndPos
+lis r10, str_N_Capture_01@ha
+addi r10, r10, str_N_Capture_01@l
+bla _compareString
+beq scalePaneAndPos
+
+lis r10, str_P_CaptureMask_00@ha
+addi r10, r10, str_P_CaptureMask_00@l
+bla _compareString
+beq scalePaneAndPos
+lis r10, str_P_CaptureMask_01@ha
+addi r10, r10, str_P_CaptureMask_01@l
+bla _compareString
+beq scalePaneAndPos
+
+lis r10, str_N_PartsSize_00@ha ; reverse scaling on pane that decides spacing between runes/items
+addi r10, r10, str_N_PartsSize_00@l
+bla _compareString
+beq scalePaneReverse
+b exitScale
+
+scaleMainHardModePanes:
+addi r5, r31, 0x80
+lis r10, str_N_InOut_00@ha
+addi r10, r10, str_N_InOut_00@l
+bla _compareString
+beq scalePaneAndKeepPos
+lis r10, str_N_Glow_00@ha
+addi r10, r10, str_N_Glow_00@l
+bla _compareString
+beq scalePaneAndKeepPos
+b exitScale
+
+scaleMapPanes:
+lis r5, copySubPanelString@ha
+lbz r5, copySubPanelString@l(r5)
+cmpwi r5, 0
+beq scaleMapNoPanes
+
+lis r5, copySubPanelString@ha
+addi r5, r5, copySubPanelString@l
+
+lis r10, str_Pa_Map_00@ha
+addi r10, r10, str_Pa_Map_00@l
+bla _compareString
+beq scaleMapTilesPanes
+; Scale sensors background back
+# lis r10, str_Pa_SensorBox_00@ha
+# addi r10, r10, str_Pa_SensorBox_00@l
+# bla _compareString
+# beq scaleMapSettingsPanes
+# lis r10, str_Pa_SubBtnChange_00@ha
+# addi r10, r10, str_Pa_SubBtnChange_00@l
+# bla _compareString
+# beq scaleMapSettingsPanes
+# ; Scale stamp box background back
+# lis r10, str_Pa_StampBox_00@ha
+# addi r10, r10, str_Pa_StampBox_00@l
+# bla _compareString
+# beq scaleMapSettingsPanes
+# lis r10, str_Pa_StampNum_00@ha
+# addi r10, r10, str_Pa_StampNum_00@l
+# bla _compareString
+# beq scaleMapSettingsPanes
+
+addi r5, r31, 0x80
+
+# lis r10, str_N_Cut_01@ha
+# addi r10, r10, str_N_Cut_01@l
+# bla _compareString
+# beq scalePaneReverse
+
+# lis r10, str_N_Sunaarashi_00@ha
+# addi r10, r10, str_N_Sunaarashi_00@l
+# bla _compareString
+# beq scalePaneReverse
+
+# lis r10, str_Pa_MapOpen_00@ha
+# addi r10, r10, str_Pa_MapOpen_00@l
+# bla _compareString
+# beq scalePaneNormal
+b exitScale
+
+scaleMapNoPanes:
+addi r5, r31, 0x80
+
+lis r10, str_N_InOut_00@ha
+addi r10, r10, str_N_InOut_00@l
+bla _compareString
+beq scaleMapAndStore
+
+lis r10, str_N_Cut_00@ha
+addi r10, r10, str_N_Cut_00@l
+bla _compareString
+beq scaleOnlySizeReverse
+
+lis r10, str_Black8_01@ha
+addi r10, r10, str_Black8_01@l
+bla _compareString
+beq scalePaneReverse
+b exitScale
+
+scaleMapTilesPanes:
+addi r5, r31, 0x80
+
+lis r10, str_B_MapCapture_00@ha
+addi r10, r10, str_B_MapCapture_00@l
+bla _compareString
+beq scaleOnlySizeReverse
+
+# lis r10, str_N_MiniMap_00@ha
+# addi r10, r10, str_N_MiniMap_00@l
+# bla _compareString
+# beq movePaneToRightSide
+b exitScale
+
+scaleMapSettingsPanes:
+addi r5, r31, 0x80
+
+lis r10, str_P_FBLayout_00@ha
+addi r10, r10, str_P_FBLayout_00@l
+bla _compareString
+beq scalePaneReverse
+lis r10, str_White8_00@ha
+addi r10, r10, str_White8_00@l
+bla _compareString
+beq scalePaneReverse
+lis r10, str_White8_01@ha
+addi r10, r10, str_White8_01@l
+bla _compareString
+beq scalePaneReverse
+lis r10, str_P_BG_03@ha
+addi r10, r10, str_P_BG_03@l
+bla _compareString
+beq scalePaneReverse
+lis r10, str_P_Abstract_00@ha
+addi r10, r10, str_P_Abstract_00@l
+bla _compareString
+beq scalePaneReverse
+lis r10, str_P_Abstract_05@ha
+addi r10, r10, str_P_Abstract_05@l
+bla _compareString
+beq scalePaneReverse
+lis r10, str_P_SSFrameCore_00@ha
+addi r10, r10, str_P_SSFrameCore_00@l
+bla _compareString
+beq scalePaneReverse
+b exitScale
+
+scaleDungeonMapPanes:
+; could-fix: hook dungeon map changing too
+lis r5, copySubPanelString@ha
+lbz r5, copySubPanelString@l(r5)
+cmpwi r5, 0
+beq scaleDungeonMapNoPanes
+
+lis r5, copySubPanelString@ha
+addi r5, r5, copySubPanelString@l
+lis r10, str_Pa_SensorBox_00@ha
+addi r10, r10, str_Pa_SensorBox_00@l
+bla _compareString
+beq scaleDungeonMapSensorBoxPanes
+lis r10, str_Pa_SubBtnChange_00@ha
+addi r10, r10, str_Pa_SubBtnChange_00@l
+bla _compareString
+beq scaleDungeonMapSensorBoxPanes
+lis r10, str_Pa_Btn_00@ha
+addi r10, r10, str_Pa_Btn_00@l
+bla _compareString
+beq scaleDungeonMapSensorBoxPanes
+
+addi r5, r31, 0x80
+b exitScale
+
+scaleDungeonMapNoPanes:
+addi r5, r31, 0x80
+lis r10, str_N_Born_00@ha
+addi r10, r10, str_N_Born_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleDungeonMapSensorBoxPanes:
+addi r5, r31, 0x80
+lis r10, str_Pa_SensorBox_00@ha
+addi r10, r10, str_Pa_SensorBox_00@l
+bla _compareString
+beq scalePaneReverse
+lis r10, str_N_BtnPos@ha
+addi r10, r10, str_N_BtnPos@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_SubIn_00@ha
+addi r10, r10, str_N_SubIn_00@l
+bla _compareString
+beq scalePaneAndPos
+lis r10, str_P_Sh_00@ha
+addi r10, r10, str_P_Sh_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_T_SensorTitle_00@ha
+addi r10, r10, str_T_SensorTitle_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleCameraPanes:
+lis r5, copySubPanelString@ha
+addi r5, r5, copySubPanelString@l
+lis r10, str_Pa_BtnZR_00@ha
+addi r10, r10, str_Pa_BtnZR_00@l
+bla _compareString
+beq scaleCameraFramePanes
+lis r10, str_Pa_Deco_00@ha
+addi r10, r10, str_Pa_Deco_00@l
+bla _compareString
+beq scaleCameraFramePanes
+
+addi r5, r31, 0x80
+lis r10, str_N_ModeCamera_00@ha
+addi r10, r10, str_N_ModeCamera_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_FirstOut_00@ha
+addi r10, r10, str_N_FirstOut_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Limit_00@ha
+addi r10, r10, str_N_Limit_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_P_Capture_00@ha
+addi r10, r10, str_P_Capture_00@l
+bla _compareString
+beq scalePaneReverse
+b exitScale
+scaleCameraFramePanes:
+addi r5, r31, 0x80
+lis r10, str_N_TimeLineDemo_00@ha
+addi r10, r10, str_N_TimeLineDemo_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_IconSeek_00@ha
+addi r10, r10, str_N_IconSeek_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleDoCommandPanes:
+addi r5, r31, 0x80
+lis r10, str_N_MS_00@ha
+addi r10, r10, str_N_MS_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+const_590:
+.float 25
+
+scalePickupPanes:
+addi r5, r31, 0x80
+lis r10, const_590@ha
+lfs f12, const_590@l(r10)
+# lis r10, str_RootPane@ha
+# addi r10, r10, str_RootPane@l
+# bla _compareString
+# beq movePaneToCustomSize
+lis r10, str_Pa_PickUpWin_00@ha
+addi r10, r10, str_Pa_PickUpWin_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+b exitScale
+
+scaleRuneGuidePanes:
+addi r5, r31, 0x80
+lis r10, str_N_Align_00@ha
+addi r10, r10, str_N_Align_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleMessageSpPanes:
+addi r5, r31, 0x80
+lis r10, str_N_Seeker_00@ha
+addi r10, r10, str_N_Seeker_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Pos_00@ha
+addi r10, r10, str_N_Pos_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_BtnNum_00@ha
+addi r10, r10, str_N_BtnNum_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Cursor_00@ha
+addi r10, r10, str_N_Cursor_00@l
+bla _compareString
+beq movePaneToRightSideAlt
+lis r10, str_B_Hit_00@ha
+addi r10, r10, str_B_Hit_00@l
+bla _compareString
+beq movePaneToRightSideAlt
+b exitScale
+
+scaleMessageDialogPanes:
+addi r5, r31, 0x80
+lis r10, str_N_Pos_00@ha
+addi r10, r10, str_N_Pos_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Cursor_00@ha
+addi r10, r10, str_N_Cursor_00@l
+bla _compareString
+beq movePaneToRightSideAlt
+lis r10, str_B_Hit_00@ha
+addi r10, r10, str_B_Hit_00@l
+bla _compareString
+beq movePaneToRightSideAlt
+b exitScale
+
+scaleMessageGetPanes:
+lis r5, copySubPanelString@ha
+addi r5, r5, copySubPanelString@l
+lis r10, str_Pa_Star_00@ha
+addi r10, r10, str_Pa_Star_00@l
+bla _compareString
+beq scaleMessageGetBackgroundAndIconPanes
+
+addi r5, r31, 0x80
+lis r10, str_N_DecideOut_00@ha
+addi r10, r10, str_N_DecideOut_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_P_Capture_01@ha
+addi r10, r10, str_P_Capture_01@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_P_Capture_04@ha
+addi r10, r10, str_P_Capture_04@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_P_Capture_02@ha
+addi r10, r10, str_P_Capture_02@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleMessageGetBackgroundAndIconPanes:
+addi r5, r31, 0x80
+lis r10, str_W_Base_00@ha
+addi r10, r10, str_W_Base_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Icon_00@ha
+addi r10, r10, str_N_Icon_00@l
+bla _compareString
+beq scalePaneAndPos
+lis r10, str_N_State_00@ha
+addi r10, r10, str_N_State_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_P_Capture_00@ha
+addi r10, r10, str_P_Capture_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_P_Capture_03@ha
+addi r10, r10, str_P_Capture_03@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_Nt_DecoLT_00@ha
+addi r10, r10, str_Nt_DecoLT_00@l
+bla _compareString
+beq scalePaneAndPos
+lis r10, str_Nt_DecoLT_01@ha
+addi r10, r10, str_Nt_DecoLT_01@l
+bla _compareString
+beq scalePaneAndPos
+lis r10, str_Nt_DecoRT_00@ha
+addi r10, r10, str_Nt_DecoRT_00@l
+bla _compareString
+beq scalePaneAndPos
+lis r10, str_Nt_DecoRT_01@ha
+addi r10, r10, str_Nt_DecoRT_01@l
+bla _compareString
+beq scalePaneAndPos
+lis r10, str_Nt_DecoLB_00@ha
+addi r10, r10, str_Nt_DecoLB_00@l
+bla _compareString
+beq scalePaneAndPos
+lis r10, str_Nt_DecoLB_01@ha
+addi r10, r10, str_Nt_DecoLB_01@l
+bla _compareString
+beq scalePaneAndPos
+lis r10, str_Nt_DecoRB_00@ha
+addi r10, r10, str_Nt_DecoRB_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_Nt_DecoRB_01@ha
+addi r10, r10, str_Nt_DecoRB_01@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleMessage3DPanes:
+addi r5, r31, 0x80
+lis r10, str_N_Capture_00@ha
+addi r10, r10, str_N_Capture_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_All_00@ha
+addi r10, r10, str_N_All_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleRuntimeMessagePanes:
+addi r5, r31, 0x80
+lis r10, str_W_Base_00@ha
+addi r10, r10, str_W_Base_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+lis r10, str_T_Text_00@ha
+addi r10, r10, str_T_Text_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+lis r10, str_T_Text_00_JPja@ha
+addi r10, r10, str_T_Text_00_JPja@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+lis r10, str_N_GuideOn_00@ha
+addi r10, r10, str_N_GuideOn_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+b exitScale
+
+scaleCursorPanes:
+addi r5, r31, 0x80
+lis r10, str_N_Porch_00@ha
+addi r10, r10, str_N_Porch_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Seek_00@ha
+addi r10, r10, str_N_Seek_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Porch_01@ha
+addi r10, r10, str_N_Porch_01@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Seek_01@ha
+addi r10, r10, str_N_Seek_01@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Porch_02@ha
+addi r10, r10, str_N_Porch_02@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Seek_02@ha
+addi r10, r10, str_N_Seek_02@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Porch_03@ha
+addi r10, r10, str_N_Porch_03@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Seek_03@ha
+addi r10, r10, str_N_Seek_03@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scalePauseMenuPanes:
+addi r5, r31, 0x80
+lis r5, copySubPanelString@ha
+lbz r5, copySubPanelString@l(r5)
+cmpwi r5, 0
+beq scalePauseMenuNoPanes
+
+lis r5, copySubPanelString@ha
+addi r5, r5, copySubPanelString@l
+
+lis r10, str_Pa_Quest_00@ha
+addi r10, r10, str_Pa_Quest_00@l
+bla _compareString
+beq scalePauseMenuQuestPanes
+
+addi r5, r31, 0x80
+lis r10, str_N_Slide_02@ha ; scales save/controller screen fully
+addi r10, r10, str_N_Slide_02@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_InCap_01@ha ; scales masks for inventory tabs
+addi r10, r10, str_N_InCap_01@l
+bla _compareString
+beq scalePaneAndPos
+lis r10, str_N_InOutGear_01@ha ; scales category and tabs in inventory screen
+addi r10, r10, str_N_InOutGear_01@l
+bla _compareString
+beq scalePaneAndPos
+
+lis r10, str_N_InOutQuest_02@ha ; scales quest slide
+addi r10, r10, str_N_InOutQuest_02@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_Pa_Page_00@ha
+addi r10, r10, str_Pa_Page_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scalePauseMenuNoPanes:
+addi r5, r31, 0x80
+lis r10, str_B_Page20_00@ha ; Scales inventory placement
+addi r10, r10, str_B_Page20_00@l
+bla _compareString
+beq scalePaneAndPos
+lis r10, str_N_InOut_00@ha ; Scales inventory screen
+addi r10, r10, str_N_InOut_00@l
+bla _compareString
+beq scalePaneAndPos
+b exitScale
+
+scalePauseMenuQuestPanes:
+addi r5, r31, 0x80
+lis r10, str_N_Cut_00@ha
+addi r10, r10, str_N_Cut_00@l
+bla _compareString
+beq scalePaneReverse
+b exitScale
+
+scalePauseMenuBGPanes: ; TODO: Maybe could look a bit nicer
+addi r5, r31, 0x80
+; lis r10, str_W_BlackBG_00@ha
+; addi r10, r10, str_W_BlackBG_00@l
+; bla _compareString
+; beq scalePaneAndSize
+; lis r10, str_N_Slide_01@ha
+; addi r10, r10, str_N_Slide_01@l
+; bla _compareString
+; beq scalePaneAndSize
+; lis r10, str_N_Slide_02@ha
+; addi r10, r10, str_N_Slide_02@l
+; bla _compareString
+; beq scalePaneAndSize
+b exitScale
+
+scalePauseMenuInfoPanes:
+lis r5, copySubPanelString@ha
+lbz r5, copySubPanelString@l(r5)
+cmpwi r5, 0
+beq scalePauseMenuInfoNoPanes
+
+addi r5, r31, 0x80
+lis r10, str_N_InOut_01@ha
+addi r10, r10, str_N_InOut_01@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Slide_00@ha
+addi r10, r10, str_N_Slide_00@l
+bla _compareString
+beq scaleOnlyPos
+lis r10, str_Pa_RotateGuide_00@ha
+addi r10, r10, str_Pa_RotateGuide_00@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+lis r10, str_N_State_00@ha
+addi r10, r10, str_N_State_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_State_03@ha
+addi r10, r10, str_N_State_03@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_TitleBar_00@ha
+addi r10, r10, str_N_TitleBar_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_TitleBarDown_00@ha
+addi r10, r10, str_N_TitleBarDown_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scalePauseMenuInfoNoPanes:
+addi r5, r31, 0x80
+; lis r10, str_N_InOut_00@ha
+; addi r10, r10, str_N_InOut_00@l
+; bla _compareString
+; beq scalePaneNormal
+b exitScale
+
+scalePauseHomePanes:
+addi r5, r31, 0x80
+lis r10, str_N_IconSeek_00@ha
+addi r10, r10, str_N_IconSeek_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_TimeLineDemo_00@ha
+addi r10, r10, str_N_TimeLineDemo_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scalePauseRunePanes:
+addi r5, r31, 0x80
+lis r10, str_N_InOut_00@ha
+addi r10, r10, str_N_InOut_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_NoContents_00@ha
+addi r10, r10, str_N_NoContents_00@l
+bla _compareString
+beq movePaneToRightSide
+b exitScale
+
+scalePauseAlbumPanes:
+addi r5, r31, 0x80
+lis r10, str_Pa_Page_00@ha
+addi r10, r10, str_Pa_Page_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_InOut_02@ha
+addi r10, r10, str_N_InOut_02@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_Pa_Photo_00@ha
+addi r10, r10, str_Pa_Photo_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_NoContents_00@ha
+addi r10, r10, str_N_NoContents_00@l
+bla _compareString
+beq movePaneToRightSide
+b exitScale
+
+scalePausePictureBookPanes:
+addi r5, r31, 0x80
+lis r10, str_Pa_Page_00@ha
+addi r10, r10, str_Pa_Page_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Contents_00@ha
+addi r10, r10, str_N_Contents_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_PartsSize_00@ha
+addi r10, r10, str_N_PartsSize_00@l
+bla _compareString
+beq scalePaneReverse
+
+lis r10, str_N_InOut_02@ha
+addi r10, r10, str_N_InOut_02@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_NoContents_00@ha
+addi r10, r10, str_N_NoContents_00@l
+bla _compareString
+beq movePaneToRightSide
+lis r10, str_N_MapPos_00@ha
+addi r10, r10, str_N_MapPos_00@l
+bla _compareString
+beq moveKeepPos
+b exitScale
+
+scaleShopHorsePanes:
+lis r5, copySubPanelString@ha
+lbz r5, copySubPanelString@l(r5)
+cmpwi r5, 0
+beq scaleShopHorseNoPanes
+
+addi r5, r31, 0x80
+lis r10, str_N_Info_00@ha
+addi r10, r10, str_N_Info_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+scaleShopHorseNoPanes:
+addi r5, r31, 0x80
+lis r10, str_N_InOut_00@ha
+addi r10, r10, str_N_InOut_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleShop05Panes:
+addi r5, r31, 0x80
+lis r10, str_N_InOut_01@ha
+addi r10, r10, str_N_InOut_01@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_InOut_02@ha
+addi r10, r10, str_N_InOut_02@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleShop20Panes:
+addi r5, r31, 0x80
+lis r10, str_N_Cut_00@ha
+addi r10, r10, str_N_Cut_00@l
+bla _compareString
+beq scaleOnlyPos
+lis r10, str_Pa_Page_4x5_00@ha
+addi r10, r10, str_Pa_Page_4x5_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_InOut_02@ha
+addi r10, r10, str_N_InOut_02@l
+bla _compareString
+beq scalePaneNormal
+# lis r10, str_N_Cat_01@ha
+# addi r10, r10, str_N_Cat_01@l
+# bla _compareString
+# beq scalePaneReverse
+b exitScale
+
+const_SkipButtonOffset:
+.float 560
+
+scaleSkipButtonPanes:
+addi r5, r31, 0x80
+lis r10, const_SkipButtonOffset@ha
+lfs f12, const_SkipButtonOffset@l(r10)
+lis r10, str_N_InOut_00@ha
+addi r10, r10, str_N_InOut_00@l
+bla _compareString
+beq scalePaneAndKeepCustomPosIf
+lis r10, str_N_Glow_00@ha
+addi r10, r10, str_N_Glow_00@l
+bla _compareString
+beq scalePaneAndKeepCustomPosIf
+b exitScale
+
+scaleLoadSaveIconPanes:
+addi r5, r31, 0x80
+lis r10, str_N_InOut_00@ha
+addi r10, r10, str_N_InOut_00@l
+bla _compareString
+beq scalePaneAndKeepPos
+lis r10, str_N_Glow_00@ha
+addi r10, r10, str_N_Glow_00@l
+bla _compareString
+beq scalePaneAndKeepPos
+b exitScale
+
+scaleLoadingPanes: ; works, but current code is very janky
+addi r5, r31, 0x80
+
+lis r10, str_N_RegionTypePos_00@ha
+addi r10, r10, str_N_RegionTypePos_00@l
+bla _compareString
+beq scalePaneToLeftSide
+lis r10, str_Pa_GuideA_00@ha
+addi r10, r10, str_Pa_GuideA_00@l
+bla _compareString
+beq scalePaneAndKeepPos
+lis r10, str_N_LogoInOut_02@ha
+addi r10, r10, str_N_LogoInOut_02@l
+bla _compareString
+beq scalePaneToRightSide
+
+lis r10, str_T_TipsTitle_00@ha
+addi r10, r10, str_T_TipsTitle_00@l
+bla _compareString
+beq scalePaneAndKeepPos
+lis r10, str_T_TipsTitle_00_JPja@ha
+addi r10, r10, str_T_TipsTitle_00_JPja@l
+bla _compareString
+beq scalePaneAndKeepPos
+lis r10, str_T_TipsTitle_00_KR@ha
+addi r10, r10, str_T_TipsTitle_00_KR@l
+bla _compareString
+beq scalePaneAndKeepPos
+lis r10, str_T_TipsTitle_00_CN@ha
+addi r10, r10, str_T_TipsTitle_00_CN@l
+bla _compareString
+beq scalePaneAndKeepPos
+lis r10, str_T_TipsTitle_00_TW@ha
+addi r10, r10, str_T_TipsTitle_00_TW@l
+bla _compareString
+beq scalePaneAndKeepPos
+lis r10, str_T_Tips_00@ha
+addi r10, r10, str_T_Tips_00@l
+bla _compareString
+beq scalePaneAndKeepPos
+lis r10, str_T_Tips_00_JPja@ha
+addi r10, r10, str_T_Tips_00_JPja@l
+bla _compareString
+beq scalePaneAndKeepPos
+lis r10, str_T_Tips_00_KR@ha
+addi r10, r10, str_T_Tips_00_KR@l
+bla _compareString
+beq scalePaneAndKeepPos
+lis r10, str_T_Tips_00_CN@ha
+addi r10, r10, str_T_Tips_00_CN@l
+bla _compareString
+beq scalePaneAndKeepPos
+lis r10, str_T_Tips_00_TW@ha
+addi r10, r10, str_T_Tips_00_TW@l
+bla _compareString
+beq scalePaneAndKeepPos
+b exitScale
+
+scaleLoadingStatusPanes:
+addi r5, r31, 0x80
+lis r10, str_N_ParamInOut_00@ha
+addi r10, r10, str_N_ParamInOut_00@l
+bla _compareString
+beq scalePaneToRightSide
+b exitScale
+
+scaleGameOverPanes:
+addi r5, r31, 0x80
+lis r10, str_N_Aka_00@ha
+addi r10, r10, str_N_Aka_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Ao_00@ha
+addi r10, r10, str_N_Ao_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Kiiro_00@ha
+addi r10, r10, str_N_Kiiro_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_Pa_Btn_00@ha
+addi r10, r10, str_Pa_Btn_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_Pa_Btn_02@ha
+addi r10, r10, str_Pa_Btn_02@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_T_SubText_00@ha
+addi r10, r10, str_T_SubText_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleSystemWindowInventoryPanes:
+addi r5, r31, 0x80
+lis r10, str_N_TypeBtn_01@ha
+addi r10, r10, str_N_TypeBtn_01@l
+bla _compareString
+beq scalePaneAndPos
+lis r10, str_N_InOut_01@ha
+addi r10, r10, str_N_InOut_01@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scalePauseMenuAbilityControlsPanes:
+addi r5, r31, 0x80
+lis r10, str_N_Option_00@ha
+addi r10, r10, str_N_Option_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Align_00@ha
+addi r10, r10, str_N_Align_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleSystemWindowPanes:
+addi r5, r31, 0x80
+lis r10, str_N_SlideArea_00@ha
+addi r10, r10, str_N_SlideArea_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_InOut_03@ha
+addi r10, r10, str_N_InOut_03@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_FileSelect_01@ha
+addi r10, r10, str_N_FileSelect_01@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_HardModePos_00@ha
+addi r10, r10, str_N_HardModePos_00@l
+bla _compareString
+beq scalePaneToLeftSide
+b exitScale
+
+scaleAppSystemWindowPanes:
+addi r5, r31, 0x80
+lis r10, str_N_BtnNum_00@ha
+addi r10, r10, str_N_BtnNum_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_BtnPos_00@ha
+addi r10, r10, str_N_BtnPos_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleOptionsMenuPanes:
+addi r5, r31, 0x80
+lis r10, str_N_Option_00@ha
+addi r10, r10, str_N_Option_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Option_01@ha
+addi r10, r10, str_N_Option_01@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleDLCWindowPanes:
+addi r5, r31, 0x80
+lis r10, str_N_Option_00@ha
+addi r10, r10, str_N_Option_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleTitlePanes:
+addi r5, r31, 0x80
+lis r10, str_N_RegionType_00@ha ; Logo
+addi r10, r10, str_N_RegionType_00@l
+bla _compareString
+beq scalePaneToRightSide
+lis r10, str_N_RegionType_00_JPja@ha ; Logo
+addi r10, r10, str_N_RegionType_00_JPja@l
+bla _compareString
+beq scalePaneToRightSide
+lis r10, str_P_Blur_08@ha ; Logo Blur
+addi r10, r10, str_P_Blur_08@l
+bla _compareString
+beq scalePaneToRightSide
+lis r10, str_N_HardMode_03@ha ; Hard Mode
+addi r10, r10, str_N_HardMode_03@l
+bla _compareString
+beq scalePaneToLeftSide
+lis r10, str_N_CopyRight_00@ha ; Copyright and version number
+addi r10, r10, str_N_CopyRight_00@l
+bla _compareString
+beq scalePaneToRightSide
+lis r10, str_N_BtnIn_00@ha ; Menu box
+addi r10, r10, str_N_BtnIn_00@l
+bla _compareString
+beq scalePaneToRightSide
+lis r10, str_N_1_Arrow_00@ha ; Backgrounds that have have no edges
+addi r10, r10, str_N_1_Arrow_00@l
+bla _compareString
+beq scalePaneToLeftSide
+lis r10, str_N_5_Gardian_00@ha
+addi r10, r10, str_N_5_Gardian_00@l
+bla _compareString
+beq scalePaneToLeftSide
+lis r10, str_N_2_Horse_00@ha
+addi r10, r10, str_N_2_Horse_00@l
+bla _compareString
+beq scalePaneToLeftSide
+lis r10, str_N_4_SenakaLink_00@ha
+addi r10, r10, str_N_4_SenakaLink_00@l
+bla _compareString
+beq scalePaneToLeftSide
+lis r10, str_N_3_Gake_00@ha ; Big backgrounds that have visible borders
+addi r10, r10, str_N_3_Gake_00@l
+bla _compareString
+beq scalePaneOnYScale
+lis r10, str_N_0_MainV_00@ha
+addi r10, r10, str_N_0_MainV_00@l
+bla _compareString
+beq scalePaneOnYScale
+lis r10, str_N_6_MainVE_00@ha
+addi r10, r10, str_N_6_MainVE_00@l
+bla _compareString
+beq scalePaneOnYScale
+b exitScale
+
+scaleDemoNameEnemyPanes:
+addi r5, r31, 0x80
+lis r10, str_N_Capture_00@ha
+addi r10, r10, str_N_Capture_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Capture_01@ha
+addi r10, r10, str_N_Capture_01@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_In_00@ha
+addi r10, r10, str_N_In_00@l
+bla _compareString
+beq scalePaneNormal
+
+lis r10, str_P_BigTextSh_00@ha
+addi r10, r10, str_P_BigTextSh_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_P_BigText_00@ha
+addi r10, r10, str_P_BigText_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_P_Light_01@ha
+addi r10, r10, str_P_Light_01@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_P_BigText_01@ha
+addi r10, r10, str_P_BigText_01@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_P_BigText_02@ha
+addi r10, r10, str_P_BigText_02@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleLastCompletePanes:
+addi r5, r31, 0x80
+lis r10, str_N_Capture_00@ha
+addi r10, r10, str_N_Capture_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_P_Base_03@ha
+addi r10, r10, str_P_Base_03@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_P_Base_01@ha
+addi r10, r10, str_P_Base_01@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_In_00@ha
+addi r10, r10, str_N_In_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_In_01@ha
+addi r10, r10, str_N_In_01@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleCreditPanes:
+addi r5, r31, 0x80
+lis r10, str_N_PicFade_00@ha
+addi r10, r10, str_N_PicFade_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_PicFade_01@ha
+addi r10, r10, str_N_PicFade_01@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_P_Sh_00@ha
+addi r10, r10, str_P_Sh_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_P_Sh_01@ha
+addi r10, r10, str_P_Sh_01@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_P_Text_01@ha
+addi r10, r10, str_P_Text_01@l
+bla _compareString
+beq scalePaneNormal
+
+lis r10, str_N_StaffRoll_00@ha
+addi r10, r10, str_N_StaffRoll_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_PostOne_03@ha
+addi r10, r10, str_N_PostOne_03@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_PostOne_02@ha
+addi r10, r10, str_N_PostOne_02@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_PostOne_01@ha
+addi r10, r10, str_N_PostOne_01@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_PostOne_00@ha
+addi r10, r10, str_N_PostOne_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_NameTriple_00@ha
+addi r10, r10, str_N_NameTriple_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_NameOne_00@ha
+addi r10, r10, str_N_NameOne_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_CopyRight_00@ha
+addi r10, r10, str_N_CopyRight_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleDLCCreditPanes:
+addi r5, r31, 0x80
+lis r10, str_N_CaptureText_00@ha
+addi r10, r10, str_N_CaptureText_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_In_00@ha
+addi r10, r10, str_N_In_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_P_BG_00@ha
+addi r10, r10, str_P_BG_00@l
+bla _compareString
+beq scalePaneReverse
+b exitScale
+
+scaleThanksPanes:
+addi r5, r31, 0x80
+lis r10, str_N_In_00@ha
+addi r10, r10, str_N_In_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Capture_00@ha
+addi r10, r10, str_N_Capture_00@l
+bla _compareString
+beq scalePaneNormal
+lis r10, str_N_Capture_01@ha
+addi r10, r10, str_N_Capture_01@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleGameTitlePanes:
+addi r5, r31, 0x80
+lis r10, str_N_Region_01@ha
+addi r10, r10, str_N_Region_01@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+lis r10, str_N_Region_01_JPja@ha
+addi r10, r10, str_N_Region_01_JPja@l
+bla _compareString
+beq scalePaneAndKeepPosIf
+b exitScale
+
+scaleMessageTipsPanes:
+lis r5, copySubPanelString@ha
+addi r5, r5, copySubPanelString@l
+
+lis r10, str_Pa_Tips_00@ha
+addi r10, r10, str_Pa_Tips_00@l
+bla _compareString
+beq scaleMessageTipsSubTipsPanes
+lis r10, str_Pa_TipsAmiibo_00@ha
+addi r10, r10, str_Pa_TipsAmiibo_00@l
+bla _compareString
+beq scaleMessageTipsSubTipsPanes
+
+addi r5, r31, 0x80
+lis r10, str_N_DecideOut_00@ha
+addi r10, r10, str_N_DecideOut_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleMessageTipsSubTipsPanes:
+addi r5, r31, 0x80
+lis r10, str_N_InOut_01@ha
+addi r10, r10, str_N_InOut_01@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+const_EnergyMeterOffset:
+.float 392
+
+scaleEnergyMeterDLCPanes:
+addi r5, r31, 0x80
+lis r10, const_EnergyMeterOffset@ha
+lfs f12, const_EnergyMeterOffset@l(r10)
+lis r10, str_N_InOut_00@ha
+addi r10, r10, str_N_InOut_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+; ------------------------------------------------------------------------------------------
+; Generic methods used to scale a specific pane type
+
+scaleRootToCenter:
+addi r5, r31, 0x80 ; address to first character of the pane name that's getting loaded
+lis r10, str_RootPane@ha
+addi r10, r10, str_RootPane@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleInOutToCenter:
+addi r5, r31, 0x80
+lis r10, str_N_InOut_00@ha
+addi r10, r10, str_N_InOut_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleTopInOutToCenter:
+lis r5, copySubPanelString@ha
+lbz r5, copySubPanelString@l(r5)
+cmpwi r5, 0
+bne exitScale
+addi r5, r31, 0x80
+lis r10, str_N_InOut_00@ha
+addi r10, r10, str_N_InOut_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleTopInOutToCenterAndPos:
+lis r5, copySubPanelString@ha
+lbz r5, copySubPanelString@l(r5)
+cmpwi r5, 0
+bne exitScale
+addi r5, r31, 0x80
+lis r10, str_N_InOut_00@ha
+addi r10, r10, str_N_InOut_00@l
+bla _compareString
+beq scalePaneAndPos
+b exitScale
+
+scaleRootScreenToLeftSide:
+addi r5, r31, 0x80
+lis r10, str_RootPane@ha
+addi r10, r10, str_RootPane@l
+bla _compareString
+beq scalePaneToLeftSide
+b exitScale
+
+scaleInOutScreenToLeftSide:
+addi r5, r31, 0x80
+lis r10, str_N_InOut_00@ha
+addi r10, r10, str_N_InOut_00@l
+bla _compareString
+beq scalePaneToLeftSide
+b exitScale
+
+scaleRootScreenToRightSide:
+addi r5, r31, 0x80
+lis r10, str_RootPane@ha
+addi r10, r10, str_RootPane@l
+bla _compareString
+beq scalePaneToRightSide
+b exitScale
+
+scaleInOutScreenToRightSide:
+addi r5, r31, 0x80
+lis r10, str_RootPane@ha
+addi r10, r10, str_RootPane@l
+bla _compareString
+beq movePaneToRightSide
+
+lis r10, str_N_InOut_00@ha
+addi r10, r10, str_N_InOut_00@l
+bla _compareString
+beq scalePaneNormal
+b exitScale
+
+scaleAllPanes:
+addi r5, r31, 0x80
+lis r10, str_RootPane@ha
+addi r10, r10, str_RootPane@l
+bla _compareString
+bne scalePaneNormal
+b exitScale
+
+; ------------------------------------------------------------------------------------------
+; Methods used to scale a single pane
+
+scalePaneAndSize:
+lis r10, const_AspectRatio@ha
+lfs f9, const_AspectRatio@l(r10)
+lfs f0, 0x0(r27)
+fmuls f0, f0, f9
+stfs f0, 0x0(r27)
+
+lis r10, const_AspectRatio@ha
+lfs f0, const_AspectRatio@l(r10)
+lfs f9, 0x34(r31)
+fmuls f0, f0, f9
+stfs f0, 0x34(r31)
+b exitScale
+
+scaleOnlySize:
+lis r10, const_AspectRatio@ha
+lfs f9, const_AspectRatio@l(r10)
+lfs f0, 0x0(r27)
+fmuls f0, f0, f9
+stfs f0, 0x0(r27)
+b exitScale
+
+scaleOnlySizeReverse:
+lis r10, const_ReverseAspectRatio@ha
+lfs f9, const_ReverseAspectRatio@l(r10)
+lfs f0, 0x0(r27)
+fmuls f0, f0, f9
+stfs f0, 0x0(r27)
+b exitScale
+
+; Scales pane to left side
+scalePaneToLeftSide:
+lis r10, const_AspectRatio@ha
+lfs f0, const_AspectRatio@l(r10)
+lfs f9, 0x34(r31)
+fmuls f0, f0, f9
+stfs f0, 0x34(r31)
+
+lis r10, const_PaddingLeftSide@ha
+lfs f9, const_PaddingLeftSide@l(r10)
+lfs f0, 0x1C(r31)
+fadds f0, f0, f9
+stfs f0, 0x1C(r31)
+b exitScale
+
+scalePaneToLeftSideIf:
+li r10, $ultrawideHUDMode
+cmpwi r10, 1
+beq scalePaneToLeftSide 
+bne scalePaneNormal
+
+movePaneToLeftSide:
+lis r10, const_PaddingLeftSide@ha
+lfs f9, const_PaddingLeftSide@l(r10)
+lfs f0, 0x1C(r31)
+fadds f0, f0, f9
+stfs f0, 0x1C(r31)
+b exitScale
+
+movePaneToLeftSideAlt:
+lis r10, const_AltPaddingLeftSide@ha
+lfs f9, const_AltPaddingLeftSide@l(r10)
+lfs f0, 0x1C(r31)
+fadds f0, f0, f9
+stfs f0, 0x1C(r31)
+b exitScale
+
+; Scales pane to right side
+scalePaneToRightSide:
+lis r10, const_AspectRatio@ha
+lfs f0, const_AspectRatio@l(r10)
+lfs f9, 0x34(r31)
+fmuls f0, f0, f9
+stfs f0, 0x34(r31)
+
+lis r10, const_PaddingRightSide@ha
+lfs f9, const_PaddingRightSide@l(r10)
+lfs f0, 0x1C(r31)
+fadds f0, f0, f9
+stfs f0, 0x1C(r31)
+b exitScale
+
+movePaneToRightSide:
+lis r10, const_PaddingRightSide@ha
+lfs f9, const_PaddingRightSide@l(r10)
+lfs f0, 0x1C(r31)
+fadds f0, f0, f9
+stfs f0, 0x1C(r31)
+b exitScale
+
+movePaneToRightSideAlt:
+lis r10, const_AltPaddingRightSide@ha
+lfs f9, const_AltPaddingRightSide@l(r10)
+lfs f0, 0x1C(r31)
+fadds f0, f0, f9
+stfs f0, 0x1C(r31)
+b exitScale
+
+scalePaneToRightSideAlt:
+lis r10, const_AspectRatio@ha
+lfs f0, const_AspectRatio@l(r10)
+lfs f9, 0x34(r31)
+fmuls f0, f0, f9
+stfs f0, 0x34(r31)
+
+lis r10, const_AltPaddingRightSide@ha
+lfs f9, const_AltPaddingRightSide@l(r10)
+lfs f0, 0x1C(r31)
+fadds f0, f0, f9
+stfs f0, 0x1C(r31)
+b exitScale
+
+scalePaneReverseToLeft:
+lis r10, const_ReverseAspectRatio@ha
+lfs f0, const_ReverseAspectRatio@l(r10)
+lfs f9, 0x34(r31)
+fmuls f0, f0, f9
+stfs f0, 0x34(r31)
+
+lis r10, const_AltPaddingLeftSide@ha
+lfs f9, const_AltPaddingLeftSide@l(r10)
+lfs f0, 0x1C(r31)
+fadds f0, f0, f9
+stfs f0, 0x1C(r31)
+b exitScale
+
+scalePaneReverseToRight:
+lis r10, const_ReverseAspectRatio@ha
+lfs f0, const_ReverseAspectRatio@l(r10)
+lfs f9, 0x34(r31)
+fmuls f0, f0, f9
+stfs f0, 0x34(r31)
+
+lis r10, const_AltPaddingRightSide@ha
+lfs f9, const_AltPaddingRightSide@l(r10)
+lfs f0, 0x1C(r31)
+fadds f0, f0, f9
+stfs f0, 0x1C(r31)
+b exitScale
+
+; Divides the width of this element with the change in aspect ratio
+scalePaneNormal:
+lis r10, const_AspectRatio@ha
+lfs f0, const_AspectRatio@l(r10)
+lfs f9, 0x34(r31)
+fmuls f0, f0, f9
+stfs f0, 0x34(r31)
+b exitScale
+
+scalePaneAndPos:
+lis r10, const_AspectRatio@ha
+lfs f0, const_AspectRatio@l(r10)
+lfs f9, 0x34(r31)
+fmuls f0, f0, f9
+stfs f0, 0x34(r31)
+
+lis r10, const_AspectRatio@ha
+lfs f0, const_AspectRatio@l(r10)
+lfs f9, 0x1C(r31)
+fmuls f0, f0, f9
+stfs f0, 0x1C(r31)
+b exitScale
+
+scaleOnlyPos:
+lis r10, const_AspectRatio@ha
+lfs f0, const_AspectRatio@l(r10)
+lfs f9, 0x1C(r31)
+fmuls f0, f0, f9
+stfs f0, 0x1C(r31)
+b exitScale
+
+const_640:
+.float $gameWidth/2
+
+const_1:
+.float 1.0
+
+scalePaneAndKeepPosIf:
+li r10, $ultrawideHUDMode
+cmpwi r10, 1
+beq scalePaneAndKeepPos 
+bne scalePaneAndPos
+
+scalePaneAndKeepPos:
+lis r10, const_AspectRatio@ha
+lfs f0, const_AspectRatio@l(r10)
+lfs f9, 0x34(r31)
+fmuls f0, f0, f9
+stfs f0, 0x34(r31)
+
+; [XPositionOfPane] + ((1280/2 - [XPositionOfPane]) * (1-[AspectRatio])))
+lis r10, const_0@ha
+lfs f11, const_0@l(r10)
+lfs f9, 0x1C(r31)
+fcmpu f9, f11
+lis r10, const_640@ha
+lfs f0, const_640@l(r10)
+lfs f9, 0x1C(r31)
+bge .+0x08
+fsubs f9, f11, f9
+fsubs f0, f0, f9
+lis r10, const_1@ha
+lfs f13, const_1@l(r10)
+lis r10, const_AspectRatio@ha
+lfs f9, const_AspectRatio@l(r10)
+fsubs f13, f13, f9
+fmuls f0, f0, f13
+lfs f9, 0x1C(r31)
+bge .+0x08
+fsubs f9, f11, f9
+fadds f0, f9, f0
+bge .+0x08
+fsubs f0, f11, f0
+stfs f0, 0x1C(r31)
+b exitScale
+
+; Pass custom pos as f12
+scalePaneAndKeepCustomPosIf:
+li r10, $ultrawideHUDMode
+cmpwi r10, 1
+beq scalePaneAndKeepCustomPos 
+bne scalePaneAndCustomPos
+
+scalePaneAndKeepCustomPos:
+lis r10, const_AspectRatio@ha
+lfs f0, const_AspectRatio@l(r10)
+lfs f9, 0x34(r31)
+fmuls f0, f0, f9
+stfs f0, 0x34(r31)
+
+; [XPositionOfPane] + ((1280/2 - [XPositionOfPane]) * (1-[AspectRatio])))
+lis r10, const_0@ha
+lfs f11, const_0@l(r10)
+lfs f9, 0x1C(r31)
+fadds f9, f9, f12
+fcmpu f9, f11
+lis r10, const_640@ha
+lfs f0, const_640@l(r10)
+lfs f9, 0x1C(r31)
+fadds f9, f9, f12
+bge .+0x08
+fsubs f9, f11, f9
+fsubs f0, f0, f9
+lis r10, const_1@ha
+lfs f13, const_1@l(r10)
+lis r10, const_AspectRatio@ha
+lfs f9, const_AspectRatio@l(r10)
+fsubs f13, f13, f9
+fmuls f0, f0, f13
+lfs f9, 0x1C(r31)
+fadds f9, f9, f12
+bge .+0x08
+fsubs f9, f11, f9
+fadds f0, f9, f0
+bge .+0x08
+fsubs f0, f11, f0
+fsubs f0, f0, f12
+stfs f0, 0x1C(r31)
+b exitScale
+
+# ; [XPositionOfPane] + ((1280/2 - [XPositionOfPane]) * (1-[AspectRatio])))
+# lis r10, const_640@ha
+# lfs f0, const_640@l(r10) ; (1280/2)
+# lfs f9, 0x1C(r31)
+# fadds f9, f9, f12        ; Create XPositionOfPane (add position of current pane + custom position of parent pane)
+# fsubs f0, f0, f9         ; (1280/2) - XPositionOfPane
+
+# lis r10, const_1@ha
+# lfs f13, const_1@l(r10)
+# lis r10, const_AspectRatio@ha
+# lfs f9, const_AspectRatio@l(r10)
+# fsubs f13, f13, f9       ; (1-[AspectRatio])
+
+# fmuls f0, f0, f13        ; ((1280/2) - XPositionOfPane) * (1-[AspectRatio])
+
+# lfs f9, 0x1C(r31)
+# fadds f9, f9, f12        ; [XPositionOfPane]
+
+# fadds f0, f9, f0         ;  [XPositionOfPane] + ((1280/2 - [XPositionOfPane]) * (1-[AspectRatio])))
+# fsubs f0, f0, f12
+
+; Explanation: The current position is 3x as big as it should be (let's take 3x at 48:9), so to correct that you scale it back by 
+; XPositionOfPane*(1-AspectRatio)
+scalePaneAndCustomPos:
+lis r10, const_AspectRatio@ha
+lfs f0,  const_AspectRatio@l(r10)
+lfs f9, 0x34(r31)
+fmuls f0, f0, f9
+stfs f0, 0x34(r31)
+
+lis r10, const_1@ha
+lfs f9, const_1@l(r10)
+lis r10, const_AspectRatio@ha
+lfs f0, const_AspectRatio@l(r10)
+fsubs f0, f9, f0
+lfs f9, 0x1C(r31)
+fsubs f9, f9, f12
+fmuls f0, f9, f0
+stfs f0, 0x1C(r31)
+b exitScale
+
+moveKeepPos:
+lis r10, const_0@ha
+lfs f11, const_0@l(r10)
+lfs f9, 0x1C(r31)
+fcmpu f9, f11
+lis r10, const_640@ha
+lfs f0, const_640@l(r10)
+lfs f9, 0x1C(r31)
+bge .+0x08
+fsubs f9, f11, f9
+fsubs f0, f0, f9
+lis r10, const_1@ha
+lfs f13, const_1@l(r10)
+lis r10, const_AspectRatio@ha
+lfs f9, const_AspectRatio@l(r10)
+fsubs f13, f13, f9
+fmuls f0, f0, f13
+lfs f9, 0x1C(r31)
+bge .+0x08
+fsubs f9, f11, f9
+fadds f0, f9, f0
+bge .+0x08
+fsubs f0, f11, f0
+stfs f0, 0x1C(r31)
+b exitScale
+
+; Pass the scale in f0 and position in f12
+scalePaneWithCustomPosAndScale:
+lfs f9, 0x34(r31)
+fmuls f0, f0, f9
+stfs f0, 0x34(r31)
+
+lfs f9, 0x1C(r31)
+fsubs f0, f9, f12
+stfs f12, 0x1C(r31)
+b exitScale
+
+movePaneToCustomPos:
+lfs f9, 0x1C(r31)
+fsubs f0, f9, f12
+stfs f12, 0x1C(r31)
+b exitScale
+
+scalePaneHalf:
+lis r10, const_AspectRatioHalf@ha
+lfs f0, const_AspectRatioHalf@l(r10)
+lfs f9, 0x34(r31)
+fmuls f0, f0, f9
+stfs f0, 0x34(r31)
+b exitScale
+
+scalePaneReverse:
+lis r10, const_ReverseAspectRatio@ha
+lfs f0, const_ReverseAspectRatio@l(r10)
+lfs f9, 0x34(r31)
+fmuls f0, f0, f9
+stfs f0, 0x34(r31)
+b exitScale
+
+scalePaneAndPosReverse:
+lis r10, const_ReverseAspectRatio@ha
+lfs f0, const_ReverseAspectRatio@l(r10)
+lfs f9, 0x34(r31)
+fmuls f0, f0, f9
+stfs f0, 0x34(r31)
+
+lis r10, const_ReverseAspectRatio@ha
+lfs f0, const_ReverseAspectRatio@l(r10)
+lfs f9, 0x1C(r31)
+fmuls f0, f0, f9
+stfs f0, 0x1C(r31)
+b exitScale
+
+scalePaneReverse2x:
+lis r10, const_ReverseAspectRatio2x@ha
+lfs f0, const_ReverseAspectRatio2x@l(r10)
+lfs f9, 0x34(r31)
+fmuls f0, f0, f9
+stfs f0, 0x34(r31)
+b exitScale
+
+scalePaneOnYScale:
+lis r10, const_ReverseAspectRatio@ha
+lfs f0, const_ReverseAspectRatio@l(r10)
+lfs f9, 0x38(r31)
+fmuls f0, f0, f9
+stfs f0, 0x38(r31)
+b exitScale
+
+scalePaneOnYScaleReverse:
+lis r10, const_AspectRatio@ha
+lfs f0, const_AspectRatio@l(r10)
+lfs f9, 0x38(r31)
+fmuls f0, f0, f9
+stfs f0, 0x38(r31)
+b exitScale
+
+scaleReversePaneToRightSide:
+lis r10, const_ReverseAspectRatio2x@ha
+lfs f0, const_ReverseAspectRatio2x@l(r10)
+lfs f9, 0x34(r31)
+fmuls f0, f0, f9
+stfs f0, 0x34(r31)
+
+lis r10, const_AltPaddingRightSide@ha
+lfs f9, const_AltPaddingRightSide@l(r10)
+lfs f0, 0x1C(r31)
+fadds f0, f0, f9
+stfs f0, 0x1C(r31)
+b exitScale
+
+exitScale:
+mtlr r0
+lwz r0, 0x24(r30)
+blr
+
+0x03C496B8 = bla _scalePaneGUI
+
+
+; ------------------------------------------------------------------------------------------
+; Specific code required for switching the positions of the minimap and the AppMap
+
+const_0:
+.float 0.0
+
+mapXPositionAddr:
+.int 0
+
+scaleMapAndStore:
+; scale pane and move to right on initialization
+lis r10, const_AspectRatio@ha
+lfs f0, const_AspectRatio@l(r10)
+lfs f9, 0x34(r31)
+fmuls f0, f0, f9
+stfs f0, 0x34(r31)
+; if the ultrawide mode is 1 (edge HUD), add padding so that the map gets initialized at the right edge
+li r10, $ultrawideHUDMode
+cmpwi r4, 1
+lis r10, const_0@ha
+lfs f9, const_0@l(r10)
+bne noMapPadding
+lis r10, const_PaddingRightSide@ha
+lfs f9, const_PaddingRightSide@l(r10)
+noMapPadding:
+lfs f0, 0x1C(r31)
+fadds f0, f0, f9
+stfs f0, 0x1C(r31)
+
+addi r5, r31, 0x1C
+lis r10, mapXPositionAddr@ha
+stw r5, mapXPositionAddr@l(r10)
+b exitScale
+
+setMapPosition:
+li r4, $ultrawideHUDMode
+cmpwi r4, 0
+beq setNothing
+
+li r4, $ultrawideHUDMode ; if ultramode is centered, keep the map centered
+cmpwi r4, 2
+beq setToMap
+
+cmpwi r31, 0
+beq setToMinimap
+
+setToMap:
+cmpwi r3, 0
+lis r3, const_0@ha
+lfs f12, const_0@l(r3)
+lis r3, mapXPositionAddr@ha
+lwz r3, mapXPositionAddr@l(r3)
+stfs f12, 0(r3)
+blr
+setToMinimap:
+cmpwi r3, 0
+lis r3, const_PaddingRightSide@ha
+lfs f12, const_PaddingRightSide@l(r3)
+lis r3, mapXPositionAddr@ha
+lwz r3, mapXPositionAddr@l(r3)
+stfs f12, 0(r3)
+blr
+setNothing:
+cmpwi r3, 0
+blr
+
+0x02F60204 = bla setMapPosition
+
+; ------------------------------------------------------------------------------------------
+; Specific code required for scaling a specific effect called PaneBasedProjection used on the weather panes, which breaks while scaling
+
+proj_PosX:
+.float 0.0
+
+proj_PosY:
+.float 0.0
+
+proj_ScaleX:
+.float ($gameWidth/$gameHeight)/($width/$height)
+
+proj_ScaleY:
+.float 1.0
+
+proj_flags:
+.int 0x01000000
+
+; other registers used: r11, r9, r12, r11
+
+; empty registers: r5, r6, r8, r0, r9, r11
+setPaneBasedProjection:
+stw r0, 0x10(r4)
+
+mr r6, r12
+mr r8, r10
+mflr r0
+
+; if ultrawide mode is set to 0, return early
+li r10, $ultrawideHUDMode
+cmpwi r10, 0
+beq exitPaneBasedProjection
+
+lis r10, copySubPanelString@ha
+addi r10, r10, copySubPanelString@l
+lis r5, str_Pa_Weather_00@ha
+addi r5, r5, str_Pa_Weather_00@l
+bla _compareString
+bne exitPaneBasedProjection
+
+# lis r11, proj_PosX@ha
+# lfs f3, proj_PosX@l(r11)
+# stfs f3, 0x0(r4)
+# lis r11, proj_PosY@ha
+# lfs f3, proj_PosY@l(r11)
+# stfs f3, 0x4(r4)
+lis r11, proj_ScaleX@ha
+lfs f3, proj_ScaleX@l(r11)
+stfs f3, 0x8(r4)
+# lis r11, proj_ScaleY@ha
+# lfs f3, proj_ScaleY@l(r11)
+# stfs f3, 0xC(r4)
+# lis r11, proj_flags@ha
+# lwz r11, proj_flags@l(r11)
+# stw r11, 0x10(r4)
+
+exitPaneBasedProjection:
+mtlr r0
+mr r12, r6
+mr r10, r8
+blr
+
+
+0x03C56CD0 = bla setPaneBasedProjection
+
+
+; ------------------------------------------------------------------------------------------
+
+_createNewScreenHook:
+; Copy screen name to buffer
+lis r11, copyScreenStringLen@ha
+lwz r11, copyScreenStringLen@l(r11)
+lis r12, copyScreenString@ha
+addi r12, r12, copyScreenString@l
+
+copyNameLoop:
+lbzx r10, r24, r11
+stbx r10, r12, r11
+addi r11, r11, -1
+cmpwi r11, -1
+bne copyNameLoop
+
+; Erase SubPanel string when a new screen got loaded
+lis r11, copySubPanelStringLen@ha
+lwz r11, copySubPanelStringLen@l(r11)
+lis r12, copySubPanelString@ha
+addi r12, r12, copySubPanelString@l
+
+eraseSubPanelLoop:
+li r10, 0
+stbx r10, r12, r11
+addi r11, r11, -1
+cmpwi r11, -1
+bne eraseSubPanelLoop
+
+li r10, $enableUltrawideDebugLogging
+cmpwi r10, 1
+blt skipLayoutFileLogging
+
+crxor 4*cr1+eq, 4*cr1+eq, 4*cr1+eq
+lis r3, newLineFormatScreen@ha
+addi r3, r3, newLineFormatScreen@l
+lis r4, copyScreenString@ha
+addi r4, r4, copyScreenString@l
+lis r5, newLineCharacter@ha
+lwz r5, newLineCharacter@l(r5)
+mflr r10
+bl import.coreinit.OSReport
+mtlr r10
+mr r3, r11
+
+skipLayoutFileLogging:
+
+lwz r11, 0xC(r30)
+blr
+
+0x03A3EDC4 = bla _createNewScreenHook
+
+; ------------------------------------------------------------------------------------------
+
+; compares the string from r5 and r10
+; r5 is untouched, so use that to do multiple comparisons
+; other registers used: r11, r9, r12, r11
+_compareString:
+mr r11, r5
+
+startLoop:
+lbz r9, 0(r11)
+lbz r12, 0(r10)
+ 
+cmpwi r9, 0
+bne checkForMatch
+cmpwi r12, 0
+bne checkForMatch
+li r10, 1
+cmpwi r10, 1
+blr
+ 
+checkForMatch:
+cmpw r9, r12
+bne noMatch
+addi r11, r11, 1
+addi r10, r10, 1
+b startLoop
+ 
+noMatch:
+li r10, 0
+cmpwi r10, 1
+blr

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/patch_GUIScreens.asm
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/patch_GUIScreens.asm
@@ -1,0 +1,676 @@
+[BotW_GUIScreenNames_V208]
+moduleMatches = 0x6267BFD0
+
+.origin = codecave
+
+; Commonly shared panes
+str_RootPane:
+.string "RootPane"
+str_N_InOut_00:
+.string "N_InOut_00"
+str_N_InOut_01:
+.string "N_InOut_01"
+str_N_InOut_02:
+.string "N_InOut_02"
+str_N_InOut_03:
+.string "N_InOut_03"
+str_N_All_00:
+.string "N_All_00"
+str_N_Pos_00:
+.string "N_Pos_00"
+str_N_BtnPos_00:
+.string "N_BtnPos_00"
+str_N_Capture_00:
+.string "N_Capture_00"
+str_N_Capture_01:
+.string "N_Capture_01"
+str_Pa_GuideA_00:
+.string "Pa_GuideA_00"
+; Panes from Title_00
+str_N_CopyRight_00:
+.string "N_CopyRight_00"
+str_N_BtnIn_00:
+.string "N_BtnIn_00"
+str_N_1_Arrow_00:
+.string "N_1_Arrow_00"
+str_N_5_Gardian_00:
+.string "N_5_Gardian_00"
+str_N_2_Horse_00:
+.string "N_2_Horse_00"
+str_N_4_SenakaLink_00:
+.string "N_4_SenakaLink_00"
+str_N_3_Gake_00:
+.string "N_3_Gake_00"
+str_N_0_MainV_00:
+.string "N_0_MainV_00"
+str_N_6_MainVE_00:
+.string "N_6_MainVE_00"
+str_N_RegionType_00:
+.string "N_RegionType_00"
+str_N_RegionType_00_JPja:
+.string "N_RegionType_00_JPja"
+str_P_Blur_08:
+.string "P_Blur_08"
+str_N_HardMode_03:
+.string "N_HardMode_03"
+
+; Panes from GameTitle_00
+str_N_Region_01:
+.string "N_Region_01"
+str_N_Region_01_JPja:
+.string "N_Region_01_JPja"
+
+; Panes from SystemWindow_01
+str_N_FileSelect_01:
+.string "N_FileSelect_01"
+str_N_SlideArea_00:
+.string "N_SlideArea_00"
+str_N_HardModePos_00:
+.string "N_HardModePos_00"
+
+; Panes from FadeStatus_00 (hearts and other elements on loading screen)
+str_N_ParamInOut_00:
+.string "N_ParamInOut_00"
+; Panes from Fade
+str_N_LogoInOut_00:
+.string "N_LogoInOut_00"
+str_P_Capture_00:
+.string "P_Capture_00"
+
+str_N_RegionTypePos_00:
+.string "N_RegionTypePos_00"
+str_N_LogoInOut_01:
+.string "N_LogoInOut_01"
+str_N_LogoInOut_02:
+.string "N_LogoInOut_02"
+
+str_T_TipsTitle_00:
+.string "T_TipsTitle_00"
+str_T_TipsTitle_00_JPja:
+.string "T_TipsTitle_00_JPja"
+str_T_TipsTitle_00_KR:
+.string "T_TipsTitle_00_KR"
+str_T_TipsTitle_00_CN:
+.string "T_TipsTitle_00_CN"
+str_T_TipsTitle_00_TW:
+.string "T_TipsTitle_00_TW"
+str_T_Tips_00:
+.string "T_Tips_00"
+str_T_Tips_00_JPja:
+.string "T_Tips_00_JPja"
+str_T_Tips_00_KR:
+.string "T_Tips_00_KR"
+str_T_Tips_00_CN:
+.string "T_TipsTitle_00_CN"
+str_T_Tips_00_TW:
+.string "T_TipsTitle_00_TW"
+; Panes from LoadSaveIcon_00
+str_Pa_SaveIcon_00:
+.string "Pa_SaveIcon_00"
+; Panes from EnergyMeterDLC_00
+scr_EnergyMeterDLC_00:
+.string "EnergyMeterDLC_00"
+str_L_EnergyMeterDLC_00:
+.string "L_EnergyMeterDLC_00"
+
+; Panes from WolfLinkHeartGauge_00
+str_P_Illust_00:
+.string "P_Illust_00"
+str_T_Name_00:
+.string "T_Name_00"
+str_Pa_HeartGauge_00:
+.string "Pa_HeartGauge_00"
+; Panes from MainScreen
+str_Pa_ArrowPointer_00:
+.string "Pa_ArrowPointer_00"
+str_Pa_ItemPointer_00:
+.string "Pa_ItemPointer_00"
+str_Pa_ThrowingPointer_00:
+.string "Pa_ThrowingPointer_00"
+str_Pa_CameraPointer_00:
+.string "Pa_CameraPointer_00"
+
+
+str_P_Icon_00:
+.string "P_Icon_00"
+str_N_SunLight_00:
+.string "N_SunLight_00"
+
+str_Pa_Gauge_00:
+.string "Pa_Gauge_00"
+str_N_State_00:
+.string "N_State_00"
+str_Pa_SinJu_00:
+.string "Pa_SinJu_00"
+str_Pa_SinJu_01:
+.string "Pa_SinJu_01"
+str_Pa_SinJu_02:
+.string "Pa_SinJu_02"
+str_Pa_SinJu_03:
+.string "Pa_SinJu_03"
+str_Pa_Sensor_00:
+.string "Pa_Sensor_00"
+str_Pa_SoundGauge_00:
+.string "Pa_SoundGauge_00"
+str_Pa_TempMeter_00:
+.string "Pa_TempMeter_00"
+str_Pa_Weather_00:
+.string "Pa_Weather_00"
+str_W_Base_00:
+.string "W_Base_00"
+str_Pa_Time_00:
+.string "Pa_Time_00"
+str_N_Icon_00:
+.string "N_Icon_00"
+
+str_Pa_BtnZR_00:
+.string "Pa_BtnZR_00"
+str_Pa_Deco_00:
+.string "Pa_Deco_00"
+
+str_P_Base_00:
+.string "P_Base_00"
+str_P_Base_01:
+.string "P_Base_01"
+str_P_Base_03:
+.string "P_Base_03"
+
+str_Pa_LocationNameS_00:
+.string "Pa_LocationNameS_00"
+str_Pa_Information_00:
+.string "Pa_Information_00"
+str_Pa_LocationName_00:
+.string "Pa_LocationName_00"
+str_Pa_BossGauge_00:
+.string "Pa_BossGauge_00"
+str_T_Time_00:
+.string "T_Time_00"
+
+str_Pa_QuestName_00:
+.string "Pa_QuestName_00"
+str_N_Dungeon_00:
+.string "N_Dungeon_00"
+
+; Panes from MainScreen3D (stamina bar, enemy spotting gauge, etc)
+str_Pa_EnemyMark_00:
+.string "Pa_EnemyMark_00"
+str_Pa_NoticeItem_00:
+.string "Pa_NoticeItem_00"
+str_Pa_StaminaGauge_00:
+.string "Pa_Ganbari_00"
+str_Pa_BonusStaminaGauge_00:
+.string "Pa_GanbariEx_00"
+str_Pa_EnemyGauge_00:
+.string "Pa_EnemyGauge_00"
+str_Pa_NoticeZ_00:
+.string "Pa_NoticeZ_00"
+str_N_ModeItem_00:
+.string "N_ModeItem_00"
+str_N_Size_05:
+.string "N_Size_05"
+str_N_Change_00:
+.string "N_Change_00"
+str_N_Change_01:
+.string "N_Change_01"
+str_N_Gauge_00:
+.string "N_Gauge_00"
+; Panes from MainDungeon_00 (dungeon loading in stuff)
+str_Pa_Message_00:
+.string "Pa_Message_00"
+str_Pa_Title_00:
+.string "Pa_Title_00"
+; Panes from MainHorse_00 (horse stamina)
+str_N_ExUse_01:
+.string "N_ExUse_01"
+; Panes from ShopHorse_00 (horse shop menu, register menu)
+scr_ShopHorse_00:
+.string "ShopHorse_00"
+str_N_Info_00:
+.string "N_Info_00"
+; Panes from ShopBtnList20_00 (Shops like Beedle)
+str_Pa_Page_4x5_00:
+.string "Pa_Page_4x5_00"
+; Panes from ShopBtnList05_00 (Shops like banana guys)
+
+; Panes from MainShortCut_00
+str_N_Cut_00:
+.string "N_Cut_00"
+str_N_MainAll_00:
+.string "N_MainAll_00"
+str_N_Cut_01:
+.string "N_Cut_01"
+str_N_PartsSize_00:
+.string "N_PartsSize_00"
+str_B_Hit_00:
+.string "B_Hit_00"
+str_P_CaptureMask_00:
+.string "P_CaptureMask_00"
+str_P_CaptureMask_01:
+.string "P_CaptureMask_01"
+
+; Panes from AppMap_00 (map screen and mini-map)
+str_Black8_01:
+.string "Black8_01"
+
+str_N_Sunaarashi_00:
+.string "N_Sunaarashi_00"
+
+str_P_FBLayout_00:
+.string "P_FBLayout_00"
+str_White8_00:
+.string "White8_00"
+str_White8_01:
+.string "White8_01"
+str_P_BG_03:
+.string "P_BG_03"
+str_P_Abstract_00:
+.string "P_Abstract_00"
+str_P_Abstract_05:
+.string "P_Abstract_05"
+str_P_SSFrameCore_00:
+.string "P_SSFrameCore_00"
+
+
+str_Pa_SensorBox_00:
+.string "Pa_SensorBox_00"
+str_Pa_SubBtnChange_00:
+.string "Pa_SubBtnChange_00"
+str_Pa_StampBox_00:
+.string "Pa_StampBox_00"
+str_Pa_StampNum_00:
+.string "Pa_StampNum_00"
+
+
+str_N_BtnPos:
+.string "N_BtnPos"
+str_N_SubIn_00:
+.string "N_SubIn_00"
+str_P_Sh_00:
+.string "P_Sh_00"
+str_P_Sh_01:
+.string "P_Sh_01"
+str_T_SensorTitle_00:
+.string "T_SensorTitle_00"
+
+str_Pa_Map_00:
+.string "Pa_Map_00"
+str_B_MapCapture_00:
+.string "B_MapCapture_00"
+str_N_MiniMap_00:
+.string "N_MiniMap_00"
+str_Pa_MapOpen_00:
+.string "Pa_MapOpen_00"
+; Panes from AppMapDungeon_00 (dungeon map)
+
+; Panes from OptionWindow_00 (settings menu)
+str_N_Option_00:
+.string "N_Option_00"
+str_N_Option_01:
+.string "N_Option_01"
+; Panes from PickUp_00
+scr_PickUp_00:
+.string "PickUp_00"
+str_Pa_PickUpWin_00:
+.string "Pa_PickUpWin_00"
+; Panes from N_MS_00
+str_N_MS_00:
+.string "N_MS_00"
+; Panes from AkashNum_00 (spirit orb amount overlay)
+scr_AkashNum_00:
+.string "AkashNum_00"
+; Panes from KologNum_00 (korok amount overlay)
+scr_KologNum_00:
+.string "KologNum_00"
+str_P_KologNuts_00:
+.string "P_KologNuts_00"
+; Panes from KeyNum_00 (key amount overlay)
+scr_KeyNum_00:
+.string "KeyNum_00"
+str_T_KeyNum_00:
+.string "T_KeyNum_00"
+; Panes from MamoNum_00 (monster coin amount overlay)
+scr_MamoNum_00:
+.string "MamoNum_00"
+str_T_Num_00:
+.string "T_Num_00"
+; Panes from Rupee_00 (rupee overlay)
+str_T_Rupee_00:
+.string "T_Rupee_00"
+; Panes from PaAppSystemWindow_00 (unsure which screen, think the save overwriting screen?)
+str_N_BtnNum_00:
+.string "N_BtnNum_00"
+; Panes from MessageSp_00 (dialog boxes and prompts)
+str_N_Seeker_00:
+.string "N_Seeker_00"
+str_MessageSp_00_NoTop:
+.string "MessageSp_00_NoTop"
+; Panes from MessageTipsRunTime_00 (runtime tips e.g. running out of stamina for the first time)
+str_T_Text_00:
+.string "T_Text_00"
+str_T_Text_00_JPja:
+.string "T_Text_00_JPja"
+str_N_GuideOn_00:
+.string "N_GuideOn_00"
+; Panes from AppCamera_00 and PaSeekPadScanningLine_00 (rune camera and camera edges)
+str_N_ModeCamera_00:
+.string "N_ModeCamera_00"
+str_N_FirstOut_00:
+.string "N_FirstOut_00"
+str_N_Limit_00:
+.string "N_Limit_00"
+
+; Panes from GameOver_00 (self-explanatory screen)
+str_Pa_Btn_00:
+.string "Pa_Btn_00"
+str_Pa_Btn_02:
+.string "Pa_Btn_02"
+str_T_SubText_00:
+.string "T_SubText_00"
+str_N_Aka_00:
+.string "N_Aka_00"
+str_N_Ao_00:
+.string "N_Ao_00"
+str_N_Kiiro_00:
+.string "N_Kiiro_00"
+
+; Panes from StaffRoll_00 (credits screen)
+str_N_CaptureText_00:
+.string "N_CaptureText_00"
+str_N_PicFade_00:
+.string "N_PicFade_00"
+str_N_PicFade_01:
+.string "N_PicFade_01"
+str_P_Text_01:
+.string "P_Text_01"
+
+str_N_StaffRoll_00:
+.string "N_StaffRoll_00"
+str_N_PostOne_03:
+.string "N_PostOne_03"
+str_N_PostOne_02:
+.string "N_PostOne_02"
+str_N_PostOne_01:
+.string "N_PostOne_01"
+str_N_PostOne_00:
+.string "N_PostOne_00"
+str_N_NameTriple_00:
+.string "N_NameTriple_00"
+str_N_NameOne_00:
+.string "N_NameOne_00"
+; Panes from StaffRollDLC_00 (credits DLC screen)
+str_N_In_00:
+.string "N_In_00"
+str_N_In_01:
+.string "N_In_01"
+str_P_BG_00:
+.string "P_BG_00"
+; Panes from DemoNameEnemy_00 (boss enemy names)
+str_P_BigTextSh_00:
+.string "P_BigTextSh_00"
+str_P_BigText_00:
+.string "P_BigText_00"
+str_P_Light_01:
+.string "P_Light_01"
+str_P_BigText_01:
+.string "P_BigText_01"
+str_P_BigText_02:
+.string "P_BigText_02"
+; Panes from MessageGet_00 (new item message screen)
+str_Nt_DecoLT_00:
+.string "Nt_DecoLT_00"
+str_Nt_DecoLT_01:
+.string "Nt_DecoLT_01"
+str_Nt_DecoRT_00:
+.string "Nt_DecoRT_00"
+str_Nt_DecoRT_01:
+.string "Nt_DecoRT_01"
+str_Nt_DecoLB_00:
+.string "Nt_DecoLB_00"
+str_Nt_DecoLB_01:
+.string "Nt_DecoLB_01"
+str_Nt_DecoRB_00:
+.string "Nt_DecoRB_00"
+str_Nt_DecoRB_01:
+.string "Nt_DecoRB_01"
+str_N_DecideOut_00:
+.string "N_DecideOut_00"
+str_Pa_Star_00:
+.string "Pa_Star_00"
+str_P_Capture_03:
+.string "P_Capture_03"
+str_P_Capture_01:
+.string "P_Capture_01"
+str_P_Capture_02:
+.string "P_Capture_02"
+str_P_Capture_04:
+.string "P_Capture_04"
+; Panes from PaMessageBtn_00 (buttons in menus and dialog options)
+str_N_Cursor_00:
+.string "N_Cursor_00"
+
+; Panes from Skip_00 (the skip button for cutscenes)
+str_N_Glow_00:
+.string "N_Glow_00"
+; Panes from Cursor_00 (the [] cursor used for some buttons in menus)
+scr_BoxCursorTV:
+.string "BoxCursorTV"
+str_N_Porch_00:
+.string "N_Porch_00"
+str_N_Seek_00:
+.string "N_Seek_00"
+str_N_Porch_01:
+.string "N_Porch_01"
+str_N_Seek_01:
+.string "N_Seek_01"
+str_N_Porch_02:
+.string "N_Porch_02"
+str_N_Seek_02:
+.string "N_Seek_02"
+str_N_Porch_03:
+.string "N_Porch_03"
+str_N_Seek_03:
+.string "N_Seek_03"
+; Panes from PauseMenu_00
+str_N_Slide_00:
+.string "N_Slide_00"
+str_N_Slide_02:
+.string "N_Slide_02"
+
+str_N_InCap_01:
+.string "N_InCap_01"
+
+str_N_InOutGear_01:
+.string "N_InOutGear_01"
+str_N_InOutQuest_02:
+.string "N_InOutQuest_02"
+str_N_State_03:
+.string "N_State_03"
+str_N_TitleBar_00:
+.string "N_TitleBar_00"
+str_N_TitleBarDown_00:
+.string "N_TitleBarDown_00"
+
+str_Pa_Quest_00:
+.string "Pa_Quest_00"
+str_Pa_Page_00:
+.string "Pa_Page_00"
+
+str_Pa_RotateGuide_00:
+.string "Pa_RotateGuide_00"
+
+str_N_Born_00:
+.string "N_Born_00"
+str_B_Page20_00:
+.string "B_Page20_00"
+
+str_N_Cat_01:
+.string "N_Cat_01"
+
+; Panes from AppHome_00 (border around App panes and opening animation)
+str_N_IconSeek_00:
+.string "N_IconSeek_00"
+str_N_TimeLineDemo_00:
+.string "N_TimeLineDemo_00"
+
+; Panes from AppTool_00 (rune window)
+str_N_NoContents_00:
+.string "N_NoContents_00"
+; Panes from AppAlbum_00 (photo/memory album)
+str_Pa_Photo_00:
+.string "Pa_Photo_00"
+; Panes from AppPictureBook_00 (picture book)
+str_N_Contents_00:
+.string "N_Contents_00"
+str_N_MapPos_00:
+.string "N_MapPos_00"
+; Panes from AppSystemWindow_00 (album image options)
+; Panes from ControllerWindow_00 (Pause menu ability controls window)
+str_N_Align_00:
+.string "N_Align_00"
+str_N_TypeBtn_01:
+.string "N_TypeBtn_01"
+; Panes from MessageTips_00 (message tips)
+str_Pa_Tips_00:
+.string "Pa_Tips_00"
+str_Pa_TipsAmiibo_00:
+.string "Pa_TipsAmiibo_00"
+scr_Title_00:
+.string "Title_00"
+scr_Fade:
+.string "Fade"
+scr_MessageDialog:
+.string "MessageDialog"
+scr_PaPlusMinus_00:
+.string "PaPlusMinus_00"
+scr_BootUp_00:
+.string "BootUp_00"
+scr_AmiiboWindow_00:
+.string "AmiiboWindow_00"
+scr_AppAlbum_00:
+.string "AppAlbum_00"
+scr_AppCamera_00:
+.string "AppCamera_00"
+scr_AppHome_00:
+.string "AppHome_00"
+scr_AppMapDungeon_00:
+.string "AppMapDungeon_00"
+scr_AppMap_00:
+.string "AppMap_00"
+scr_AppPictureBook_00:
+.string "AppPictureBook_00"
+scr_AppSystemWindowNoBtn_00:
+.string "AppSystemWindowNoBtn_00"
+scr_AppSystemWindow_00:
+.string "AppSystemWindow_00"
+scr_AppTool_00:
+.string "AppTool_00"
+scr_ChallengeWin_00:
+.string "ChallengeWin_00"
+scr_ChangeController_00:
+.string "ChangeController_00"
+scr_ChangeControllerDRC_00:
+.string "ChangeControllerDRC_00"
+scr_ControllerWindow_00:
+.string "ControllerWindow_00"
+scr_DemoNameEnemy_00:
+.string "DemoNameEnemy_00"
+scr_DemoName_00:
+.string "DemoName_00"
+scr_DLCWindow_00:
+.string "DLCWindow_00"
+scr_DoCommand_00:
+.string "DoCommand_00"
+scr_End_00:
+.string "End_00"
+scr_FadeStatus_00:
+.string "FadeStatus_00"
+scr_GameOver_00:
+.string "GameOver_00"
+scr_GamePadBG_00:
+.string "GamePadBG_00"
+scr_GameTitle_00:
+.string "GameTitle_00"
+scr_HardModeTextDLC_00:
+.string "HardModeTextDLC_00"
+scr_HardMode_00:
+.string "HardMode_00"
+scr_KeyBoradTextArea_00:
+.string "KeyBoradTextArea_00"
+scr_LastComplete_00:
+.string "LastComplete_00"
+scr_LoadSaveIcon_00:
+.string "LoadSaveIcon_00"
+scr_MainDungeon_00:
+.string "MainDungeon_00"
+scr_MainHardMode_00:
+.string "MainHardMode_00"
+scr_MainHorse_00:
+.string "MainHorse_00"
+scr_MainScreen3D_00:
+.string "MainScreen3D_00"
+scr_MainScreenMS_00: ; Used to show hearts decreasing when you draw the master sword
+.string "MainScreenMS_00"
+scr_MainScreen_00:
+.string "MainScreen_00"
+scr_MainShortCut_00:
+.string "MainShortCut_00"
+scr_Message3D_00:
+.string "Message3D_00"
+scr_DemoMessage:
+.string "DemoMessage"
+scr_DemoMessage_00:
+.string "DemoMessage_00"
+scr_DemoName:
+.string "DemoName"
+scr_DemoNameEnemy:
+.string "DemoNameEnemy"
+scr_MessageGet_00:
+.string "MessageGet_00"
+scr_MessageSp_00:
+.string "MessageSp_00"
+scr_MessageTipsRunTime_00:
+.string "MessageTipsRunTime_00"
+scr_MessageTips_00:
+.string "MessageTips_00"
+scr_OPtext_00:
+.string "OPtext_00"
+scr_OptionWindow_00:
+.string "OptionWindow_00"
+scr_PauseMenuBG_00:
+.string "PauseMenuBG_00"
+scr_PauseMenuInfo_00:
+.string "PauseMenuInfo_00"
+scr_PauseMenuMantan_00:
+.string "PauseMenuMantan_00"
+scr_PauseMenuRecipe_00:
+.string "PauseMenuRecipe_00"
+scr_PauseMenu_00:
+.string "PauseMenu_00"
+scr_Rupee_00:
+.string "Rupee_00"
+scr_ShopBtnList15_00:
+.string "ShopBtnList15_00"
+scr_ShopBtnList20_00:
+.string "ShopBtnList20_00"
+scr_ShopBtnList5_00:
+.string "ShopBtnList5_00"
+scr_ShopInfo_00:
+.string "ShopInfo_00"
+scr_Skip_00:
+.string "Skip_00"
+scr_SousaGuide_00:
+.string "SousaGuide_00"
+scr_StaffRollDLC_00:
+.string "StaffRollDLC_00"
+scr_StaffRoll_00:
+.string "StaffRoll_00"
+scr_SystemWindow_00:
+.string "SystemWindow_00"
+scr_SystemWindow_01:
+.string "SystemWindow_01"
+scr_Thanks_00:
+.string "Thanks_00"
+scr_Time_00:
+.string "Time_00"
+scr_WolfLinkHeartGauge_00:
+.string "WolfLinkHeartGauge_00"

--- a/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/rules.txt
+++ b/src/BreathOfTheWild/Workarounds/GraphicsNon16By9/rules.txt
@@ -1,0 +1,669 @@
+[Definition]
+titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
+name = Graphics (16:10 Effect Fix)
+path = "The Legend of Zelda: Breath of the Wild/Workarounds/Graphics (16:10 Effect Fix)"
+description = Replacement for the Graphics pack that fixes rain and shadow artifacts at non-16:9 aspect ratios (16:10, 21:9, 4:3, etc). Disable the main Graphics pack and enable this instead.||Keeps the main framebuffer upscale and the shadow cascade upscale, but skips the depth-pyramid downsample upscale chain which causes artifacts when the render aspect differs from 16:9.||Based on the original Graphics pack by Kiri, Skalfate, rajkosto and NAVras.
+version = 7
+
+[Default]
+$width = 1280
+$height = 720
+$gameWidth = 1280
+$gameHeight = 720
+$aspectRatioWidth = 16
+$aspectRatioHeight = 9
+$showUltrawideOptions:int = 0
+$showSquareHUDOption:int = 0
+$ultrawideHUDMode:int = 0
+$fxaa:int = 1
+$shadowRes = 1
+$subPix:int = 1.0
+$edgeThreshold:int = 0.125
+$edgeThresholdMin:int = 0.0156
+
+$shadowNearbyStart = 1.0 # the starting distance should be kept at 1.0
+$shadowNearbyEnd = 1.0
+$shadowFarStart = 1.0
+$shadowFarEnd = 1.0
+
+# Should be set to 1 or 2 (changes verbosity of loggin) when trying to log the layout of panes while they're getting loaded for debugging purposes
+$enableUltrawideDebugLogging:int = 0
+
+# Aspect Ratio
+
+[Preset]
+name = 16:9 (Default)
+category = Aspect Ratio
+$aspectRatioWidth = 16
+$aspectRatioHeight = 9
+$showUltrawideOptions:int = 0
+$ultrawideHUDMode:int = 0
+
+[Preset]
+name = 16:10
+category = Aspect Ratio
+$aspectRatioWidth = 16
+$aspectRatioHeight = 10
+$showUltrawideOptions:int = 0
+$ultrawideHUDMode:int = 0
+
+[Preset]
+name = 21:9
+category = Aspect Ratio
+$aspectRatioWidth = 21
+$aspectRatioHeight = 9
+$showUltrawideOptions:int = 1
+
+[Preset]
+name = 32:9
+category = Aspect Ratio
+$aspectRatioWidth = 32
+$aspectRatioHeight = 9
+$showUltrawideOptions:int = 1
+
+[Preset]
+name = 32:10
+category = Aspect Ratio
+$aspectRatioWidth = 32
+$aspectRatioHeight = 10
+$showUltrawideOptions:int = 1
+
+[Preset]
+name = 48:9
+category = Aspect Ratio
+$aspectRatioWidth = 48
+$aspectRatioHeight = 9
+$showUltrawideOptions:int = 1
+
+[Preset]
+name = 4:3
+category = Aspect Ratio
+$aspectRatioWidth = 4
+$aspectRatioHeight = 3
+$showSquareHUDOption:int = 1
+
+[Preset]
+name = 5:4
+category = Aspect Ratio
+$aspectRatioWidth = 5
+$aspectRatioHeight = 4
+$showSquareHUDOption:int = 1
+
+[Preset]
+name = 3:2
+category = Aspect Ratio
+$aspectRatioWidth = 3
+$aspectRatioHeight = 2
+$showSquareHUDOption:int = 1
+
+# 16:9 Resolutions
+
+[Preset]
+name = 320x180
+category = Resolution
+condition = ((($aspectRatioWidth - 16) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 320
+$height = 180
+
+[Preset]
+name = 640x360
+category = Resolution
+condition = ((($aspectRatioWidth - 16) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 640
+$height = 360
+
+[Preset]
+name = 960x540
+category = Resolution
+condition = ((($aspectRatioWidth - 16) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 960
+$height = 540
+
+[Preset]
+name = 1280x720 (HD, Default)
+category = Resolution
+condition = ((($aspectRatioWidth - 16) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+default = 1
+
+[Preset]
+name = 1600x900 (HD+)
+category = Resolution
+condition = ((($aspectRatioWidth - 16) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 1600
+$height = 900
+
+[Preset]
+name = 1920x1080 (Full HD)
+category = Resolution
+condition = ((($aspectRatioWidth - 16) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 1920
+$height = 1080
+
+[Preset]
+name = 2560x1440 (2K)
+category = Resolution
+condition = ((($aspectRatioWidth - 16) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 2560
+$height = 1440
+
+[Preset]
+name = 3200x1800
+category = Resolution
+condition = ((($aspectRatioWidth - 16) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 3200
+$height = 1800
+
+[Preset]
+name = 3840x2160 (4K)
+category = Resolution
+condition = ((($aspectRatioWidth - 16) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 3840
+$height = 2160
+
+[Preset]
+name = 5120x2880 (5K)
+category = Resolution
+condition = ((($aspectRatioWidth - 16) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 5120
+$height = 2880
+
+[Preset]
+name = 7680x4320 (8K)
+category = Resolution
+condition = ((($aspectRatioWidth - 16) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 7680
+$height = 4320
+
+[Preset]
+name = 10240x5760 (10K)
+category = Resolution
+condition = ((($aspectRatioWidth - 16) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 10240
+$height = 5760
+
+# 16:10 Resolutions
+
+[Preset]
+name = 1280x800
+category = Resolution
+condition = ((($aspectRatioWidth - 16) == 0) + (($aspectRatioHeight - 10) == 0)) == 2
+$width = 1280
+$height = 800
+
+[Preset]
+name = 1440x900
+category = Resolution
+condition = ((($aspectRatioWidth - 16) == 0) + (($aspectRatioHeight - 10) == 0)) == 2
+$width = 1440
+$height = 900
+
+[Preset]
+name = 1680x1050
+category = Resolution
+condition = ((($aspectRatioWidth - 16) == 0) + (($aspectRatioHeight - 10) == 0)) == 2
+$width = 1680
+$height = 1050
+
+[Preset]
+name = 1920x1200
+category = Resolution
+condition = ((($aspectRatioWidth - 16) == 0) + (($aspectRatioHeight - 10) == 0)) == 2
+$width = 1920
+$height = 1200
+
+[Preset]
+name = 2560x1600
+category = Resolution
+condition = ((($aspectRatioWidth - 16) == 0) + (($aspectRatioHeight - 10) == 0)) == 2
+$width = 2560
+$height = 1600
+
+[Preset]
+name = 2880x1800
+category = Resolution
+condition = ((($aspectRatioWidth - 16) == 0) + (($aspectRatioHeight - 10) == 0)) == 2
+$width = 2880
+$height = 1800
+
+[Preset]
+name = 3840x2400
+category = Resolution
+condition = ((($aspectRatioWidth - 16) == 0) + (($aspectRatioHeight - 10) == 0)) == 2
+$width = 3840
+$height = 2400
+
+[Preset]
+name = 5120x3200
+category = Resolution
+condition = ((($aspectRatioWidth - 16) == 0) + (($aspectRatioHeight - 10) == 0)) == 2
+$width = 5120
+$height = 3200
+
+# 21:9 Resolutions
+
+[Preset]
+name = 1720x720
+category = Resolution
+condition = ((($aspectRatioWidth - 21) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 1720
+$height = 720
+
+[Preset]
+name = 2100x900
+category = Resolution
+condition = ((($aspectRatioWidth - 21) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 2100
+$height = 900
+
+[Preset]
+name = 2560x1080
+category = Resolution
+condition = ((($aspectRatioWidth - 21) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 2560
+$height = 1080
+
+[Preset]
+name = 3440x1440
+category = Resolution
+condition = ((($aspectRatioWidth - 21) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 3440
+$height = 1440
+
+[Preset]
+name = 3840x1600
+category = Resolution
+condition = ((($aspectRatioWidth - 21) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 3840
+$height = 1600
+
+[Preset]
+name = 4300x1800
+category = Resolution
+condition = ((($aspectRatioWidth - 21) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 4300
+$height = 1800
+
+[Preset]
+name = 5120x2160
+category = Resolution
+condition = ((($aspectRatioWidth - 21) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 5120
+$height = 2160
+
+[Preset]
+name = 6880x2880
+category = Resolution
+condition = ((($aspectRatioWidth - 21) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 6880
+$height = 2880
+
+[Preset]
+name = 10240x4320
+category = Resolution
+condition = ((($aspectRatioWidth - 21) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 10240
+$height = 4320
+
+# 32:9 Resolutions
+
+[Preset]
+name = 3840x1080
+category = Resolution
+condition = ((($aspectRatioWidth - 32) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 3840
+$height = 1080
+
+[Preset]
+name = 5120x1440
+category = Resolution
+condition = ((($aspectRatioWidth - 32) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 5120
+$height = 1440
+
+[Preset]
+name = 7680x2160
+category = Resolution
+condition = ((($aspectRatioWidth - 32) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 7680
+$height = 2160
+
+[Preset]
+name = 10240x2880
+category = Resolution
+condition = ((($aspectRatioWidth - 32) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 10240
+$height = 2880
+
+# 31:10 Resolutions
+
+[Preset]
+name = 3840x1200
+category = Resolution
+condition = ((($aspectRatioWidth - 32) == 0) + (($aspectRatioHeight - 10) == 0)) == 2
+$width = 3840
+$height = 1200
+
+[Preset]
+name = 5760x1800
+category = Resolution
+condition = ((($aspectRatioWidth - 32) == 0) + (($aspectRatioHeight - 10) == 0)) == 2
+$width = 5760
+$height = 1800
+
+[Preset]
+name = 7680x2400
+category = Resolution
+condition = ((($aspectRatioWidth - 32) == 0) + (($aspectRatioHeight - 10) == 0)) == 2
+$width = 7680
+$height = 2400
+
+# 48:9 Resolutions
+
+[Preset]
+name = 5760x1080
+category = Resolution
+condition = ((($aspectRatioWidth - 48) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 5760
+$height = 1080
+
+[Preset]
+name = 7680x1440
+category = Resolution
+condition = ((($aspectRatioWidth - 48) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 7680
+$height = 1440
+
+[Preset]
+name = 11520x2160
+category = Resolution
+condition = ((($aspectRatioWidth - 48) == 0) + (($aspectRatioHeight - 9) == 0)) == 2
+$width = 11520
+$height = 2160
+
+# 4:3 Resolutions
+
+[Preset]
+name = 800x600
+category = Resolution
+condition = ((($aspectRatioWidth - 4) == 0) + (($aspectRatioHeight - 3) == 0)) == 2
+$width = 800
+$height = 600
+
+[Preset]
+name = 1024x768
+category = Resolution
+condition = ((($aspectRatioWidth - 4) == 0) + (($aspectRatioHeight - 3) == 0)) == 2
+$width = 1024
+$height = 768
+
+[Preset]
+name = 1280x960
+category = Resolution
+condition = ((($aspectRatioWidth - 4) == 0) + (($aspectRatioHeight - 3) == 0)) == 2
+$width = 1280
+$height = 960
+
+[Preset]
+name = 1600x1200
+category = Resolution
+condition = ((($aspectRatioWidth - 4) == 0) + (($aspectRatioHeight - 3) == 0)) == 2
+$width = 1600
+$height = 1200
+
+[Preset]
+name = 1920x1440
+category = Resolution
+condition = ((($aspectRatioWidth - 4) == 0) + (($aspectRatioHeight - 3) == 0)) == 2
+$width = 1920
+$height = 1440
+
+# 5:4 Resolutions
+
+[Preset]
+name = 1280x1024
+category = Resolution
+condition = ((($aspectRatioWidth - 5) == 0) + (($aspectRatioHeight - 4) == 0)) == 2
+$width = 1280
+$height = 1024
+
+[Preset]
+name = 5760x1080 (3 Full HD )
+category = Resolution
+condition = ((($aspectRatioWidth - 5) == 0) + (($aspectRatioHeight - 4) == 0)) == 2
+$width = 5760
+$height = 1080
+
+[Preset]
+name = 8640x1620
+category = Resolution
+condition = ((($aspectRatioWidth - 5) == 0) + (($aspectRatioHeight - 4) == 0)) == 2
+$width = 8640
+$height = 1620
+
+[Preset]
+name = 14400x2700
+category = Resolution
+condition = ((($aspectRatioWidth - 5) == 0) + (($aspectRatioHeight - 4) == 0)) == 2
+$width = 14400
+$height = 2700
+
+# 3:2 Resolutions
+
+[Preset]
+name = 1080x720
+category = Resolution
+condition = ((($aspectRatioWidth - 3) == 0) + (($aspectRatioHeight - 2) == 0)) == 2
+$width = 1080
+$height = 720
+
+[Preset]
+name = 1440x960
+category = Resolution
+condition = ((($aspectRatioWidth - 3) == 0) + (($aspectRatioHeight - 2) == 0)) == 2
+$width = 1440
+$height = 960
+
+[Preset]
+name = 1920x1280
+category = Resolution
+condition = ((($aspectRatioWidth - 3) == 0) + (($aspectRatioHeight - 2) == 0)) == 2
+$width = 1920
+$height = 1280
+
+[Preset]
+name = 2256x1504
+category = Resolution
+condition = ((($aspectRatioWidth - 3) == 0) + (($aspectRatioHeight - 2) == 0)) == 2
+$width = 2256
+$height = 1504
+
+[Preset]
+name = 3240x2160
+category = Resolution
+condition = ((($aspectRatioWidth - 3) == 0) + (($aspectRatioHeight - 2) == 0)) == 2
+$width = 3240
+$height = 2160
+
+# Ultrawide Mode Options
+
+[Preset]
+name = Edge HUD (Default)
+category = Ultrawide HUD Mode
+condition = $showUltrawideOptions == 1
+$ultrawideHUDMode:int = 1
+default = 1
+
+[Preset]
+name = Centered HUD
+category = Ultrawide HUD Mode
+condition = $showUltrawideOptions == 1
+$ultrawideHUDMode:int = 2
+
+[Preset]
+name = No HUD Fixes (stretched HUD)
+condition = $showUltrawideOptions == 1
+category = Ultrawide HUD Mode
+$ultrawideHUDMode:int = 0
+
+# Square HUD Mode Options
+
+[Preset]
+name = Disabled (Default)
+category = Square HUD Mode
+condition = $showSquareHUDOption == 1
+$ultrawideHUDMode:int = 0
+default = 1
+
+[Preset]
+name = Enabled (Experimental, Will Have Some Issues)
+category = Square HUD Mode
+condition = $showSquareHUDOption == 1
+$ultrawideHUDMode:int = 1
+
+# Anti-Aliasing
+
+[Preset]
+name = None
+category = Anti-Aliasing
+$fxaa:int = 0
+
+[Preset]
+name = NVIDIA FXAA
+category = Anti-Aliasing
+$fxaa:int = 2
+
+[Preset]
+name = Normal FXAA (Default)
+category = Anti-Aliasing
+default = 1
+
+# Shadow Graphics Pack
+
+[Preset]
+name = Low (50%)
+category = Shadows
+$shadowRes = 0.5
+
+[Preset]
+name = Medium (100%, Default)
+default = 1
+category = Shadows
+
+[Preset]
+name = High (200%)
+category = Shadows
+$shadowRes = 2
+
+[Preset]
+name = Ultra (300%)
+category = Shadows
+$shadowRes = 3
+
+[Preset]
+name = Extreme (400%, Unstable)
+category = Shadows
+$shadowRes = 4
+
+# Shadow Draw Distance
+
+[Preset]
+category = Shadow Draw Distance
+name = Low (Low Draw Distance, Sharp Shadows)
+$shadowNearbyEnd = 0.6
+$shadowFarStart = 0.6
+$shadowFarEnd = 0.75
+
+[Preset]
+name = Medium (Lower Draw Distance, Sharper Shadows)
+category = Shadow Draw Distance
+$shadowNearbyEnd = 0.8
+$shadowFarStart = 0.8
+$shadowFarEnd = 0.9
+
+[Preset]
+name = High (Default)
+category = Shadow Draw Distance
+default = 1
+
+[Preset]
+name = Very High (Recommended)
+category = Shadow Draw Distance
+$shadowNearbyEnd = 1.25
+$shadowFarStart = 1.25
+$shadowFarEnd = 1.30
+
+[Preset]
+name = Ultra (Higher Draw Distance, Slightly Blurrier Shadows)
+category = Shadow Draw Distance
+$shadowNearbyEnd = 1.3
+$shadowFarStart = 1.3
+$shadowFarEnd = 1.5
+
+[Preset]
+name = Extreme (Higher Draw Distance, Blurry Shadows)
+category = Shadow Draw Distance
+$shadowNearbyEnd = 1.4
+$shadowFarStart = 1.4
+$shadowFarEnd = 1.55
+
+
+# Texture Changes
+
+# All 720p textures:
+# - 0x001=World Lighting Red8
+# - 0x005=Link and Objects Depth
+# - 0x007=World Lighting Red-Green Texture
+# - 0x019=Menu Interface/GUI
+# - 0x01a=Normals
+# - 0x41a=Geometry rendering
+# - 0x806=Wind/Fog
+# - 0x80e=Depth stencil buffer
+# - 0x816=Weapon and Objects Bloom
+# - 0x820=Field Fog
+
+# Depth/Geometry/Shading Rendering
+[TextureRedefine]
+width = 1280
+height = 720
+formats = 0x001,0x005,0x007,0x019,0x01a,0x41a,0x80e,0x806,0x816,0x820
+# formatsExcluded = 0x008 # Game Load Opening Background Image
+tileModesExcluded = 0x001 # For Video Playback
+overwriteWidth = ($width/$gameWidth) * 1280
+overwriteHeight = ($height/$gameHeight) * 720
+
+# Shadows Graphic Pack
+
+[TextureRedefine]
+width = 768
+height = 720
+formats = 0x005
+overwriteWidth = $shadowRes * 768
+overwriteHeight = $shadowRes * 720
+
+[TextureRedefine]
+width = 720
+height = 720
+formats = 0x005
+overwriteWidth = $shadowRes * 720
+overwriteHeight = $shadowRes * 720
+
+[TextureRedefine]
+width = 384
+height = 368
+formats = 0x005
+overwriteWidth = $shadowRes * 384
+overwriteHeight = $shadowRes * 368
+
+[TextureRedefine]
+width = 384
+height = 360
+formats = 0x005
+overwriteWidth = $shadowRes * 384
+overwriteHeight = $shadowRes * 360
+
+[TextureRedefine]
+width = 360
+height = 360
+formats = 0x005
+overwriteWidth = $shadowRes * 360
+overwriteHeight = $shadowRes * 360


### PR DESCRIPTION
## What this fixes

At non-16:9 resolutions (16:10, 21:9, 4:3, 3:2, etc.), BotW exhibits two rendering artifacts that persist even with #744 applied:

1. **Rain bottom-strip** — when it's raining and the camera is pitched downward, a horizontal strip of broken rain particles appears at the bottom of the screen. Most visible on Steam Deck at native 1280×800 and on any 16:10 display at 1920×1200.
2. **Shadow cascade seam** — the pre-existing #568 bug, partially addressed by #744 but still visible at non-16:9 aspects.

Both artifacts disappear when the aspect ratio is switched to 16:9 in the Graphics pack, confirming the bugs are driven by how the depth-pyramid `TextureRedefine` entries scale at non-uniform aspect ratios.

## Root cause

The Graphics pack scales the entire depth pyramid proportionally with `$width/$gameWidth` and `$height/$gameHeight`. At 16:9 these ratios are equal (uniform scaling) so the depth pyramid stays proportionally consistent: main is N× the source, half-res is (N/2)×, quarter-res is (N/4)×, etc.

At non-16:9 the ratios diverge. For example at 1280×800:
- `$width/$gameWidth = 1.0`
- `$height/$gameHeight = 1.111`

This introduces a non-uniform Y stretch in every depth-pyramid downsample-chain `TextureRedefine`. BotW's rain pixel shader samples half-res depth using hardcoded native-720 assumptions, and when Cemu stretches the half-res depth buffer to match the upscaled main framebuffer, the rain shader's sampling near the bottom of the screen reads out-of-expected-range rows.

This was verified empirically by bisection of the Graphics pack's `TextureRedefine` entries on Steam Deck 1280×800:
- **0 depth-chain entries** (only main framebuffer upscaled): artifact-free
- **Half-res depth pair added** (`640×368` + `640×360`): rain strip appears
- Any further entries added: rain strip persists
- Modifying the half-res pair formulas to equalize the two buffers: introduces a shadow cascade seam (the 8-pixel padding gap is required for cascade alignment correctness)

We could not find a formula-level workaround. We also could not patch the rain pixel shader without identifying its hash (future work).

The only consistent, artifact-free configurations are:
1. All depth-pyramid entries scaled (current main pack — correct at 16:9 only)
2. Only the main framebuffer scaled, all downsample-chain entries left at native dimensions (this PR — correct at all aspects)

## The fix

Adds a new workaround pack at `src/BreathOfTheWild/Workarounds/GraphicsNon16By9/` that is a drop-in replacement for the main Graphics pack at non-16:9 aspect ratios:

- Identical `[Definition]` (modified name/path/description only), `[Default]` variables, all `[Preset]` blocks (aspect ratio, resolution, ultrawide HUD, AA, shadows, shadow draw distance)
- Identical `patch_AspectRatio.asm`, `patch_GUIAspectRatio.asm`, `patch_GUIScreens.asm`
- Identical shader patches (all 37 `*.vs.txt` / `*.ps.txt` files from `Graphics/`)
- **Only one rendering `TextureRedefine`**: the main framebuffer (1280×720 → user-selected resolution)
- Plus the five shadow cascade `TextureRedefine` entries (aspect-independent, driven by `$shadowRes`)
- All other depth/bloom/GUI/cubemap downsample `TextureRedefine` entries from `Graphics/rules.txt` are removed

Total: 41 files. The 40 non-`rules.txt` files are byte-identical copies of the corresponding files in `Graphics/`, so the pack is fully self-contained and tracks `Graphics/` for any future shader/asm updates that need to be re-mirrored.

Users at non-16:9 aspect ratios disable the main Graphics pack and enable this workaround pack instead. Users at 16:9 continue to use the main Graphics pack as before — **the main Graphics pack is unchanged by this PR**.

## Quality tradeoff

Non-16:9 users lose the depth-pyramid upscale chain for downsampled effects (SSAO, fog masks, bloom downsamples). At 1280×800 on Steam Deck (the most common use case for this fix), the difference is imperceptible — verified across multiple scenes and weather states.

## Testing

- **Steam Deck 1280×800 (native)**: rain strip gone, shadow cascade seam gone, general rendering flawless. Tested across multiple biomes (Hyrule Field, Akkala, Hateno), weather states (rain/clear), and camera angles (flat/steep downward).
- **1920×1200 16:10**: rain strip gone, shadow cascade seam gone.
- **16:9 users**: unaffected (main Graphics pack unchanged).

## Why not gate conditionally inside the existing Graphics pack

Cemu's `TextureRedefine` parser silently ignores `condition = ...` clauses inside `[TextureRedefine]` blocks (verified empirically with both an aspect-ratio condition and an always-false condition — neither prevented the entries from applying). It also does not evaluate complex formulas with user-defined integer variables in arithmetic expressions like `$useDepthPyramid * X + (1 - $useDepthPyramid) * Y` (verified with a `$useDepthPyramid:int = 0` toggle that had no effect on the rendered output). Without a working conditional mechanism inside `rules.txt`, a separate pack is the cleanest approach that preserves zero regression for 16:9 users.

## Related

- #568 — original BotW shadow cascade seam report
- #744 — open PR for the half-res rounding fix; this PR is **complementary**, not a replacement. #744 helps 16:9 users; this PR fixes the larger non-16:9 artifact class.

## File list

```
src/BreathOfTheWild/Workarounds/GraphicsNon16By9/
├── rules.txt                       (the actual fix — 669 lines, 6 TextureRedefines)
├── patch_AspectRatio.asm           (byte-identical copy from Graphics/)
├── patch_GUIAspectRatio.asm        (byte-identical copy)
├── patch_GUIScreens.asm            (byte-identical copy)
└── *.vs.txt / *.ps.txt             (37 shader patches, byte-identical copies)
```