### PR TITLE
[BotW] Fix rain and shadow artifacts at non-16:9 resolutions

### DIFF
--- a/src/BreathOfTheWild/Graphics/rules.txt
+++ b/src/BreathOfTheWild/Graphics/rules.txt
@@ -26,6 +26,10 @@ $shadowNearbyEnd = 1.0
 $shadowFarStart = 1.0
 $shadowFarEnd = 1.0
 
+# 16:10 fix: skip half-res buffer upscale at non-16:9 aspects to prevent
+# rain particle strip and shadow cascade seam. Set by aspect ratio preset.
+$sixteenByTenFix = 0
+
 # Should be set to 1 or 2 (changes verbosity of loggin) when trying to log the layout of panes while they're getting loaded for debugging purposes
 $enableUltrawideDebugLogging:int = 0
 
@@ -111,6 +115,7 @@ $aspectRatioWidth = 16
 $aspectRatioHeight = 10
 $showUltrawideOptions:int = 0
 $ultrawideHUDMode:int = 0
+$sixteenByTenFix = 1
 
 [Preset]
 name = 21:9
@@ -119,6 +124,7 @@ condition = $betterVRExposeVROptions == 0
 $aspectRatioWidth = 21
 $aspectRatioHeight = 9
 $showUltrawideOptions:int = 1
+$sixteenByTenFix = 1
 
 [Preset]
 name = 32:9
@@ -127,6 +133,7 @@ condition = $betterVRExposeVROptions == 0
 $aspectRatioWidth = 32
 $aspectRatioHeight = 9
 $showUltrawideOptions:int = 1
+$sixteenByTenFix = 1
 
 [Preset]
 name = 32:10
@@ -135,6 +142,7 @@ condition = $betterVRExposeVROptions == 0
 $aspectRatioWidth = 32
 $aspectRatioHeight = 10
 $showUltrawideOptions:int = 1
+$sixteenByTenFix = 1
 
 [Preset]
 name = 48:9
@@ -143,6 +151,7 @@ condition = $betterVRExposeVROptions == 0
 $aspectRatioWidth = 48
 $aspectRatioHeight = 9
 $showUltrawideOptions:int = 1
+$sixteenByTenFix = 1
 
 [Preset]
 name = 4:3
@@ -151,6 +160,7 @@ condition = $betterVRExposeVROptions == 0
 $aspectRatioWidth = 4
 $aspectRatioHeight = 3
 $showSquareHUDOption:int = 1
+$sixteenByTenFix = 1
 
 [Preset]
 name = 5:4
@@ -159,6 +169,7 @@ condition = $betterVRExposeVROptions == 0
 $aspectRatioWidth = 5
 $aspectRatioHeight = 4
 $showSquareHUDOption:int = 1
+$sixteenByTenFix = 1
 
 [Preset]
 name = 3:2
@@ -167,6 +178,7 @@ condition = $betterVRExposeVROptions == 0
 $aspectRatioWidth = 3
 $aspectRatioHeight = 2
 $showSquareHUDOption:int = 1
+$sixteenByTenFix = 1
 
 # 16:9 Resolutions
 
@@ -731,24 +743,24 @@ overwriteHeight = ($height/$gameHeight) * 480
 # - 0x816=World & Weapon Bloom
 # - 0x820=Fog
 
-# Required 1/2 resolutions
+# Required 1/2 resolutions (gated: non-16:9 aspects keep native size to avoid rain/shadow artifacts)
 [TextureRedefine]
 width = 640
 height = 368
 formats = 0x001,0x005,0x007,0x019,0x01a,0x80e,0x806,0x816,0x820,0x41a
 # formatsExcluded = 0x431 # Exclude 0x431 which is used for adventure log images
-overwriteWidth = ($width/$gameWidth) * 640
-overwriteHeight = (($height/$gameHeight) * 368) + 0.49
+overwriteWidth = $sixteenByTenFix * 640 + (1 - $sixteenByTenFix) * (($width/$gameWidth) * 640)
+overwriteHeight = $sixteenByTenFix * 368 + (1 - $sixteenByTenFix) * (($height/$gameHeight) * 368)
 
-# Required 1/2 resolutions
+# Required 1/2 resolutions (gated: non-16:9 aspects keep native size to avoid rain/shadow artifacts)
 [TextureRedefine]
 width = 640
 height = 360
 formats = 0x001,0x005,0x007,0x019,0x01a,0x80e,0x806,0x816,0x820,0x41a
 # formatsExcluded = 0x431
 tileModesExcluded = 0x001 # For Video Playback
-overwriteWidth = ($width/$gameWidth) * 640
-overwriteHeight = ($height/$gameHeight) * 360
+overwriteWidth = $sixteenByTenFix * 640 + (1 - $sixteenByTenFix) * (($width/$gameWidth) * 640)
+overwriteHeight = $sixteenByTenFix * 360 + (1 - $sixteenByTenFix) * (($height/$gameHeight) * 360)
 
 # Required 1/3 resolutions
 [TextureRedefine]
@@ -1070,7 +1082,7 @@ height = 368
 formats = 0x019
 overwriteFormat = 0x01f
 overwriteWidth = ($width/$gameWidth) * 640
-overwriteHeight = (($height/$gameHeight) * 368) + 0.49
+overwriteHeight = ($height/$gameHeight) * 368
 
 [TextureRedefine]
 width = 640


### PR DESCRIPTION
## What this fixes

When playing Breath of the Wild at non-16:9 aspect ratios (16:10, 21:9, 32:9, etc.), two visual bugs appear:

1. **Rain strip** — a horizontal band of broken rain particles at the bottom of the screen when the camera looks down during rain
2. **Shadow line** — a dark horizontal line across the ground between shadow cascade levels

Both issues are most visible on Steam Deck at its native 1280×800 (16:10) resolution.

## Why it happens

The Graphics pack scales all internal buffers to match the selected resolution. At 16:9, horizontal and vertical scale factors are equal, so everything stays proportional. At non-16:9 resolutions (like 16:10), the vertical factor is slightly larger than the horizontal one. The half-resolution buffers (640×368 and 640×360) get stretched unevenly, which breaks the rain shader's depth sampling and causes the shadow cascade mismatch.

## The fix

A new variable `$sixteenByTenFix` is set automatically when a non-16:9 aspect ratio is selected. It keeps the two half-res buffers at their original size instead of stretching them. At 16:9, everything works exactly as before — zero changes for existing users.

Also removes a `+0.49` rounding hack on the 640×368 height formula that contributed to the shadow line at non-16:9.

## Testing

- **Steam Deck 1280×800**: rain strip gone, shadow line gone, all scenes look correct
- **1920×1200 (16:10)**: same, both artifacts gone
- **16:9 resolutions**: no change in behavior, verified at 1920×1080 and 2560×1440

## Changes

One file: `src/BreathOfTheWild/Graphics/rules.txt` (+19 lines, −7 lines)