### PR TITLE
Add Devil's Third 60FPS unlock

### DIFF
--- a/Mods/DevilsThird_60FPS/patch_fpscap.asm
+++ b/Mods/DevilsThird_60FPS/patch_fpscap.asm
@@ -1,0 +1,4 @@
+[Uncap frame rate to 60]
+moduleMatches = 0xd148e8e6
+
+0x03B87F2C = b 0x03B8808C # skips the hardcoded 50 FPS wait

--- a/Mods/DevilsThird_60FPS/rules.txt
+++ b/Mods/DevilsThird_60FPS/rules.txt
@@ -1,0 +1,6 @@
+[Definition]
+titleIds = 0005000010177600,0005000010177700,0005000010197d00
+name = 60FPS
+path = "Devil's Third/Mods/60FPS"
+description = Removes the 50 FPS cap on menus and gameplay raising them to 60. Leaves the 30 FPS cap on cinematics and loading screens untouched. Made by AbbieDoobie.
+version = 4


### PR DESCRIPTION
## Summary
- Adds a 60FPS mod for Devil's Third (USA, v16 - titleIds 0005000010177600/0005000010177700/0005000010197d00)
- Removes a hardcoded 50 FPS cap in the engine's main tick loop, raising menu/gameplay to 60 FPS
- Cinematics and loading screens are untouched (still native 30 FPS)

## Test plan
- Verified live via Cemu's PPC debugger against the confirmed RPX checksum (moduleMatches)
- Confirmed across all game states (initial load, cinematic, menu, loading, gameplay) that only menu/gameplay change (50->60), with cinematic/loading and movie playback unaffected